### PR TITLE
Add nvidia support

### DIFF
--- a/patches/nvidia-0001-Fix-for-22.04-build.patch
+++ b/patches/nvidia-0001-Fix-for-22.04-build.patch
@@ -1,0 +1,36 @@
+From 93866d1908e963d73af829c37e1c99d12ae661eb Mon Sep 17 00:00:00 2001
+From: Stéphane Graber <stgraber@ubuntu.com>
+Date: Tue, 28 Feb 2023 01:16:25 +0000
+Subject: [PATCH] Fix for 22.04 build
+
+Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>
+---
+ Makefile | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 00d561e..8710bfd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -18,7 +18,7 @@
+ ##### Global variables #####
+ 
+ WITH_NVCGO   ?= yes
+-WITH_LIBELF  ?= no
++WITH_LIBELF  ?= yes
+ WITH_TIRPC   ?= no
+ WITH_SECCOMP ?= yes
+ 
+@@ -168,6 +168,9 @@ ifeq ($(WITH_TIRPC), yes)
+ LIB_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
+ LIB_LDLIBS_STATIC  += -l:libtirpc.a
+ LIB_LDLIBS_SHARED  += -lpthread
++else
++LIB_CPPFLAGS       += $(shell pkg-config --cflags libtirpc)
++LIB_LDLIBS_SHARED  += $(shell pkg-config --libs libtirpc)
+ endif
+ ifeq ($(WITH_SECCOMP), yes)
+ LIB_CPPFLAGS       += -DWITH_SECCOMP $(shell pkg-config --cflags libseccomp)
+-- 
+2.34.1
+

--- a/snap/hooks/connect-plug-graphics-core22
+++ b/snap/hooks/connect-plug-graphics-core22
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+# Ensure nvidia support setup correctly #
+if snapctl is-connected nvidia-core22:graphics-core22 ; then
+
+    # Generate the CDI config #
+    $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"
+
+    # Generate the dockerd runtime config #
+    $SNAP/usr/bin/nvidia-ctk runtime configure --runtime=docker --runtime-path "$SNAP/usr/bin/nvidia-ctk" --config "$SNAP_DATA/config/daemon.json"
+
+    # Restart dockerd to reflect any changes #
+    snap restart "$SNAP_NAME.dockerd"
+
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,3 +8,22 @@ fi
 
 # ensure the layouts dir for /etc/docker exists
 mkdir -p "$SNAP_DATA/etc/docker"
+
+# ensure the layouts dir for /etc/cdi exists
+mkdir -p "$SNAP_DATA/etc/cdi"
+
+# Ensure nvidia support setup correctly #
+if snapctl is-connected opengl ; then
+    if snapctl is-connected nvidia-core22:graphics-core22 ; then
+
+        # Generate the CDI config #
+        $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"
+
+        # Generate the dockerd runtime config #
+        $SNAP/usr/bin/nvidia-ctk runtime configure --runtime=docker --runtime-path "$SNAP/usr/bin/nvidia-ctk" --config "$SNAP_DATA/config/daemon.json"
+
+        # Restart dockerd to reflect any changes #
+        snap restart "$SNAP_NAME.dockerd"
+
+    fi
+fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -13,17 +13,15 @@ mkdir -p "$SNAP_DATA/etc/docker"
 mkdir -p "$SNAP_DATA/etc/cdi"
 
 # Ensure nvidia support setup correctly #
-if snapctl is-connected opengl ; then
-    if snapctl is-connected nvidia-core22:graphics-core22 ; then
+if snapctl is-connected nvidia-core22:graphics-core22 ; then
 
-        # Generate the CDI config #
-        $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"
+    # Generate the CDI config #
+    $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"
 
-        # Generate the dockerd runtime config #
-        $SNAP/usr/bin/nvidia-ctk runtime configure --runtime=docker --runtime-path "$SNAP/usr/bin/nvidia-ctk" --config "$SNAP_DATA/config/daemon.json"
+    # Generate the dockerd runtime config #
+    $SNAP/usr/bin/nvidia-ctk runtime configure --runtime=docker --runtime-path "$SNAP/usr/bin/nvidia-ctk" --config "$SNAP_DATA/config/daemon.json"
 
-        # Restart dockerd to reflect any changes #
-        snap restart "$SNAP_NAME.dockerd"
+    # Restart dockerd to reflect any changes #
+    snap restart "$SNAP_NAME.dockerd"
 
-    fi
 fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -5,3 +5,19 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
     mkdir -p "$SNAP_DATA/config"
     cp "$SNAP/config/daemon.json" "$SNAP_DATA/config/daemon.json"
 fi
+
+# Ensure nvidia support setup correctly #
+if snapctl is-connected opengl ; then
+    if snapctl is-connected nvidia-core22:graphics-core22 ; then
+
+        # Generate the CDI config #
+        $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"
+
+        # Generate the dockerd runtime config #
+        $SNAP/usr/bin/nvidia-ctk runtime configure --runtime=docker --runtime-path "$SNAP/usr/bin/nvidia-ctk" --config "$SNAP_DATA/config/daemon.json"
+
+        # Restart dockerd to reflect any changes #
+        snap restart "$SNAP_NAME.dockerd"
+
+    fi
+fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -7,17 +7,15 @@ if [ ! -f "$SNAP_DATA/config/daemon.json" ]; then
 fi
 
 # Ensure nvidia support setup correctly #
-if snapctl is-connected opengl ; then
-    if snapctl is-connected nvidia-core22:graphics-core22 ; then
+if snapctl is-connected nvidia-core22:graphics-core22 ; then
 
-        # Generate the CDI config #
-        $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"
+    # Generate the CDI config #
+    $SNAP/usr/bin/nvidia-ctk cdi generate --nvidia-ctk-path "$SNAP/usr/bin/nvidia-ctk" --output="$SNAP_DATA/etc/cdi/nvidia.yaml"
 
-        # Generate the dockerd runtime config #
-        $SNAP/usr/bin/nvidia-ctk runtime configure --runtime=docker --runtime-path "$SNAP/usr/bin/nvidia-ctk" --config "$SNAP_DATA/config/daemon.json"
+    # Generate the dockerd runtime config #
+    $SNAP/usr/bin/nvidia-ctk runtime configure --runtime=docker --runtime-path "$SNAP/usr/bin/nvidia-ctk" --config "$SNAP_DATA/config/daemon.json"
 
-        # Restart dockerd to reflect any changes #
-        snap restart "$SNAP_NAME.dockerd"
+    # Restart dockerd to reflect any changes #
+    snap restart "$SNAP_NAME.dockerd"
 
-    fi
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,12 +35,6 @@ base: core22
 confinement: strict
 assumes: [snapd2.50]
 
-environment:
-  # For nvidia support #
-  LD_LIBRARY_PATH:    $SNAP/graphics/lib:${SNAP}/lib/:${SNAP}/lib/${SNAPCRAFT_ARCH_TRIPLET}:${SNAP}/usr/lib/:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
-  LIBGL_DRIVERS_PATH: $SNAP/graphics/dri
-  LIBVA_DRIVERS_PATH: $SNAP/graphics/dri
-
 layout:
   /etc/docker:
     bind: $SNAP_DATA/etc/docker
@@ -55,6 +49,10 @@ layout:
 environment:
   GIT_EXEC_PATH: "$SNAP/usr/lib/git-core"
   GIT_TEMPLATE_DIR: "$SNAP/usr/share/git-core/templates"
+  # For nvidia support #
+  LD_LIBRARY_PATH:    $SNAP/graphics/lib:${SNAP}/lib/:${SNAP}/lib/${SNAPCRAFT_ARCH_TRIPLET}:${SNAP}/usr/lib/:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
+  LIBGL_DRIVERS_PATH: $SNAP/graphics/dri
+  LIBVA_DRIVERS_PATH: $SNAP/graphics/dri
 
 plugs:
   home:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -222,7 +222,17 @@ parts:
     source: https://github.com/NVIDIA/nvidia-container-toolkit.git
     source-tag: v1.12.0
     source-depth: 1
+    override-pull: |
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && \
+        [ "${CRAFT_TARGET_ARCH}" != "arm64" ] && \
+        exit 0
+
+      craftctl default
     override-build: |
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && \
+        [ "${CRAFT_TARGET_ARCH}" != "arm64" ] && \
+        exit 0
+
       craftctl default
 
       # From nvidia-container-toolkit package postinst
@@ -233,16 +243,24 @@ parts:
     organize:
       bin: usr/bin/
     stage:
-      - usr/bin/nvidia-container-toolkit
-      - usr/bin/nvidia-container-runtime
-      - usr/bin/nvidia-container-runtime-hook
+      - usr/bin/nvidia-container-*
 
   libnvidia-container:
     plugin: make
     source: https://github.com/NVIDIA/libnvidia-container.git
     source-tag: v1.12.0
     source-depth: 1
+    override-pull: |
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && \
+        [ "${CRAFT_TARGET_ARCH}" != "arm64" ] && \
+        exit 0
+
+      craftctl default
     override-build: |
+      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && \
+        [ "${CRAFT_TARGET_ARCH}" != "arm64" ] && \
+        exit 0
+
       patch -p1 < "${CRAFT_PROJECT_DIR}/patches/nvidia-0001-Fix-for-22.04-build.patch"
 
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,8 @@ plugs:
   graphics-core22:
     interface: content
     target: $SNAP/graphics
-    default-provider: nvidia-core22
+    # Currnelty, this is the only relavent provier, but cannot be default as not supported on all archs #
+    #default-provider: nvidia-core22
 slots:
   docker-daemon:
     interface: docker

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,9 +234,6 @@ parts:
         exit 0
 
       craftctl default
-
-      # From nvidia-container-toolkit package postinst
-      (cd "${CRAFT_PART_INSTALL}/bin" && ln -s nvidia-container-runtime-hook nvidia-container-toolkit)
     build-snaps: *go
     build-packages:
       - make

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -218,25 +218,24 @@ parts:
       - make
 
   nvidia-container-toolkit:
-    plugin: make
+    plugin: go
     source: https://github.com/NVIDIA/nvidia-container-toolkit.git
     source-tag: v1.12.0
     source-depth: 1
     override-build: |
-      PLATFORM_DIST="ubuntu18.04"
-
-      make ${PLATFORM_DIST}
-
-      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/nvidia-container-toolkit_*.deb ${SNAPCRAFT_PART_INSTALL}
-      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/nvidia-container-toolkit-base_*.deb ${SNAPCRAFT_PART_INSTALL}
+      craftctl default
 
       # From nvidia-container-toolkit package postinst
-      (cd "$SNAPCRAFT_PART_INSTALL/usr/bin" && ln -s nvidia-container-runtime-hook nvidia-container-toolkit)
+      (cd "${CRAFT_PART_INSTALL}/bin" && ln -s nvidia-container-runtime-hook nvidia-container-toolkit)
+    build-snaps: *go
     build-packages:
       - make
-    # Recursive - could also use docker.io build-packages #
-    build-snaps:
-      - docker
+    organize:
+      bin: usr/bin/
+    stage:
+      - usr/bin/nvidia-container-toolkit
+      - usr/bin/nvidia-container-runtime
+      - usr/bin/nvidia-container-runtime-hook
 
   libnvidia-container:
     plugin: make
@@ -244,17 +243,20 @@ parts:
     source-tag: v1.12.0
     source-depth: 1
     override-build: |
-      PLATFORM_DIST="ubuntu18.04"
+      patch -p1 < "${CRAFT_PROJECT_DIR}/patches/nvidia-0001-Fix-for-22.04-build.patch"
 
-      make ${PLATFORM_DIST}
-
-      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/libnvidia-container1_*.deb ${SNAPCRAFT_PART_INSTALL}
-      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/libnvidia-container-tools_*.deb ${SNAPCRAFT_PART_INSTALL}
+      craftctl default
     build-packages:
-      - make
-    # Recursive - could also use docker.io build-packages #
-    build-snaps:
-      - docker
+      - bmake
+      - libelf-dev
+      - libcap-dev
+    # Paths taken from upstream packaging #
+    organize:
+      usr/local/bin/nvidia-container-cli: usr/bin/nvidia-container-cli
+      usr/local/lib: usr/lib/${CRAFT_ARCH_TRIPLET}/
+    prime:
+      - usr/bin/nvidia-container-cli*
+      - usr/lib/${CRAFT_ARCH_TRIPLET}/libnvidia-container*.so*
 
   libnetwork:
     plugin: make

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,9 +35,18 @@ base: core22
 confinement: strict
 assumes: [snapd2.50]
 
+environment:
+  # For nvidia support #
+  LD_LIBRARY_PATH:    $SNAP/graphics/lib:${SNAP}/lib/:${SNAP}/lib/${SNAPCRAFT_ARCH_TRIPLET}:${SNAP}/usr/lib/:${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
+  LIBGL_DRIVERS_PATH: $SNAP/graphics/dri
+  LIBVA_DRIVERS_PATH: $SNAP/graphics/dri
+
 layout:
   /etc/docker:
     bind: $SNAP_DATA/etc/docker
+  # Container Device Interface (CDI) Support - https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#container-device-interface-cdi-support
+  /etc/cdi:
+    bind: $SNAP_DATA/etc/cdi
   /etc/gitconfig:
     bind-file: $SNAP_DATA/etc/gitconfig
   /usr/libexec/docker/cli-plugins:
@@ -58,6 +67,11 @@ plugs:
     privileged-containers: true
   docker-cli:
     interface: docker
+  # For nvidia userspace libs support #
+  graphics-core22:
+    interface: content
+    target: $SNAP/graphics
+    default-provider: nvidia-core22
 slots:
   docker-daemon:
     interface: docker
@@ -93,6 +107,7 @@ apps:
       - network-control
       - privileged
       - support
+      - graphics-core22
     slots:
       - docker-daemon
 
@@ -201,6 +216,45 @@ parts:
       - libapparmor-dev
       - libseccomp-dev
       - make
+
+  nvidia-container-toolkit:
+    plugin: make
+    source: https://github.com/NVIDIA/nvidia-container-toolkit.git
+    source-tag: v1.12.0
+    source-depth: 1
+    override-build: |
+      PLATFORM_DIST="ubuntu18.04"
+
+      make ${PLATFORM_DIST}
+
+      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/nvidia-container-toolkit_*.deb ${SNAPCRAFT_PART_INSTALL}
+      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/nvidia-container-toolkit-base_*.deb ${SNAPCRAFT_PART_INSTALL}
+
+      # From nvidia-container-toolkit package postinst
+      (cd "$SNAPCRAFT_PART_INSTALL/usr/bin" && ln -s nvidia-container-runtime-hook nvidia-container-toolkit)
+    build-packages:
+      - make
+    # Recursive - could also use docker.io build-packages #
+    build-snaps:
+      - docker
+
+  libnvidia-container:
+    plugin: make
+    source: https://github.com/NVIDIA/libnvidia-container.git
+    source-tag: v1.12.0
+    source-depth: 1
+    override-build: |
+      PLATFORM_DIST="ubuntu18.04"
+
+      make ${PLATFORM_DIST}
+
+      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/libnvidia-container1_*.deb ${SNAPCRAFT_PART_INSTALL}
+      dpkg-deb -x ${SNAPCRAFT_PART_BUILD}/dist/${PLATFORM_DIST}/${SNAPCRAFT_TARGET_ARCH}/libnvidia-container-tools_*.deb ${SNAPCRAFT_PART_INSTALL}
+    build-packages:
+      - make
+    # Recursive - could also use docker.io build-packages #
+    build-snaps:
+      - docker
 
   libnetwork:
     plugin: make


### PR DESCRIPTION
This adds support for containers to access NVIDIA GPUs for acceleration

https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html

Adds related configuration and components from:
- nvidia-container-toolkit
- libnvidia-container

Also adds content interface plug for graphics-core22 provided by nvidia-core22 snap, containing required nvidia userspace libs.

Relates to: https://github.com/docker-snap/docker-snap/issues/91
