### PR TITLE
Revert "Exclude wheel"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -372,8 +372,6 @@ parts:
     source: https://github.com/docker/compose.git
     source-tag: 1.29.2
     source-depth: 1
-    stage:
-      - -lib/python3.6/site-packages/wheel*
     build-packages:
       - libffi-dev
       # for "cryptography" on non-wheel arches


### PR DESCRIPTION
This reverts commit 617ffeaee91ca541b843547e0e2a4444aba260bc.

Reason for revert: base is bumped to core22, which uses python3.10. So this is no-op now.