### PR TITLE
Change GH workflows to publish the snap to Store for Nvidia testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+
+on:
+  workflow_run:
+    workflows: ["trigger"]
+    types:
+      - completed
+
+defaults:
+  run:
+    shell: 'bash -Eeuo pipefail -x {0}'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        uses: snapcore/action-build@v1
+        id: snapcraft
+        with:
+          snapcraft-args: snap --output docker_${{ github.run_id}}.snap
+
+      - name: Upload
+        # TODO: the goal of this "if:" condition is to avoid creating artifacts on private forks (and using up all their storage quota),
+        # but Tianon couldn't find a clean way to do that so this was the next best thing
+        if: github.repository == 'canonical/docker-snap'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker_${{ github.run_id}}.snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,12 +4,6 @@ on:
   pull_request:
   push:
 
-on:
-  workflow_run:
-    workflows: ["trigger"]
-    types:
-      - completed
-
 defaults:
   run:
     shell: 'bash -Eeuo pipefail -x {0}'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,10 +4,6 @@ on:
   pull_request:
   push:
 
-defaults:
-  run:
-    shell: 'bash -Eeuo pipefail -x {0}'
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,9 +18,6 @@ jobs:
           snapcraft-args: snap --output docker_${{ github.run_id}}.snap
 
       - name: Upload
-        # TODO: the goal of this "if:" condition is to avoid creating artifacts on private forks (and using up all their storage quota),
-        # but Tianon couldn't find a clean way to do that so this was the next best thing
-        if: github.repository == 'canonical/docker-snap'
         uses: actions/upload-artifact@v4
         with:
           name: docker_${{ github.run_id}}.snap

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -34,15 +34,15 @@ jobs:
               uses: dawidd6/action-download-artifact@v6
               with:
                 workflow: build.yml
-                name: docker_${{ github.event.inputs.run_id }}.snap
+                name: docker_${{ inputs.run_id }}.snap
 
             - name: Publish to Store
               uses: snapcore/action-publish@v1
               env:
                 SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
               with:
-                snap: docker_${{ github.event.inputs.run_id }}.snap
-                release: latest/edge/runid-${{ github.event.inputs.run_id }}
+                snap: docker_${{ inputs.run_id }}.snap
+                release: latest/edge/runid-${{ inputs.run_id }}
 
             - name: Create Testflinger job queue
               run: |

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -47,7 +47,7 @@ jobs:
             - name: Create Testflinger job queue
               run: |
                 export JOB_QUEUE="${{ matrix.job-queue }}"
-                export SNAP_CHANNEL="${{ inputs.snap-channel }}"
+                export SNAP_CHANNEL="latest/edge/runid-${{ github.event.inputs.run_id }}"
 
                 envsubst '$JOB_QUEUE' \
                   < $TESTFLINGER_DIR/nvidia-job.yaml \

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -7,11 +7,10 @@ on:
   # Manual trigger
   workflow_dispatch:
     inputs:
-      snap-channel:
-        description: 'Docker snap channel'
+      run_id:
+        description: 'Run id number'
         required: true
-        type: string
-        default: 'latest/edge'
+        type: number
 
 jobs:
     test:
@@ -31,11 +30,25 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Get the artifact
+              uses: dawidd6/action-download-artifact@v6
+              with:
+                workflow: build.yml
+                name: docker_${{ github.event.inputs.run_id }}.snap
+
+            - name: Publish to Store
+              uses: snapcore/action-publish@v1
+              env:
+                SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
+              with:
+                snap: docker_${{ github.event.inputs.run_id }}.snap
+                release: latest/edge/runid-${{ github.event.inputs.run_id }}
+
             - name: Create Testflinger job queue
               run: |
                 export JOB_QUEUE="${{ matrix.job-queue }}"
                 export SNAP_CHANNEL="${{ inputs.snap-channel }}"
-                
+
                 envsubst '$JOB_QUEUE' \
                   < $TESTFLINGER_DIR/nvidia-job.yaml \
                   > $TESTFLINGER_DIR/nvidia-job.temp

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -47,7 +47,7 @@ jobs:
             - name: Create Testflinger job queue
               run: |
                 export JOB_QUEUE="${{ matrix.job-queue }}"
-                export SNAP_CHANNEL="latest/edge/runid-${{ github.event.inputs.run_id }}"
+                export SNAP_CHANNEL="latest/edge/runid-${{ inputs.run_id }}"
 
                 envsubst '$JOB_QUEUE' \
                   < $TESTFLINGER_DIR/nvidia-job.yaml \

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
   push:
 
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
 defaults:
   run:
     shell: 'bash -Eeuo pipefail -x {0}'
@@ -15,19 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build
-        # https://github.com/snapcore/action-build/releases
-        uses: snapcore/action-build@v1
+      - name: Get the artifact
+        uses: dawidd6/action-download-artifact@v6
         with:
-          snapcraft-args: snap --output docker.snap
-
-      - name: Upload
-        # TODO the goal of this "if:" condition is to avoid creating artifacts on private forks (and using up all their storage quota), but Tianon couldn't find a clean way to do that so this was the next best thing
-        if: github.repository == 'docker-snap/docker-snap'
-        uses: actions/upload-artifact@v2
-        with:
-          name: docker.snap
-          path: docker.snap
+          workflow: build.yml
+          name: docker_[0-9]+.snap
+          name_is_regexp: true
 
       - name: Prep
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,9 +1,6 @@
 name: Smoke Test
 
 on:
-  pull_request:
-  push:
-
   workflow_run:
     workflows: ["Build"]
     types:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,6 +17,7 @@ jobs:
   smoke-test:
     name: Snapcraft
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Get the artifact
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Install
         run: |
+          # dawidd6/action-download-artifact action creates a directory when the name is fetch as a RegExp
           cd ./docker_*.snap
           sudo snap install --dangerous ./docker_*.snap
           # it will immediately be failing to start, so let's head that off as quickly as we can

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,7 +12,6 @@ defaults:
 
 jobs:
   smoke-test:
-    name: Snapcraft
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
@@ -45,9 +44,10 @@ jobs:
 
       - name: Install
         run: |
-          # dawidd6/action-download-artifact action creates a directory when the name is fetch as a RegExp
+          # dawidd6/action-download-artifact action creates a directory when the name is given as a RegExp
           cd ./docker_*.snap
           sudo snap install --dangerous ./docker_*.snap
+
           # it will immediately be failing to start, so let's head that off as quickly as we can
           sudo snap stop --disable docker.dockerd
           sudo killall dockerd || :

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Install
         run: |
-          sudo snap install --dangerous ./docker.snap
+          cd ./docker_*.snap
+          sudo snap install --dangerous ./docker_*.snap
           # it will immediately be failing to start, so let's head that off as quickly as we can
           sudo snap stop --disable docker.dockerd
           sudo killall dockerd || :


### PR DESCRIPTION
Add possibility to run nvidia workflow for artifacts of PRs and separate build and upload artifact on a dedicated workflow.

- Add: workflow to build and upload artifact
- Feat: Add possibility to run nvidia tests by passing the run-id of the wanted build workflow.