### PR TITLE
ci: Refine triggers to avoid replicated runs on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,11 @@
 name: Build
 
 on:
-  pull_request:
   push:
+    branches: [ main ]
+  pull_request:
+  # Manual trigger
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Currently, the snap gets built twice on PRs that intend to merge code from a local branch.

This change sets the branch for PR triggers to `main`, avoiding runs on pushes to other local branches in a PR.

Also, enables manual triggers.