### PR TITLE
ci: Make the artifact download workflow step less dependent on build workflow name

### DIFF
--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -33,7 +33,8 @@ jobs:
             - name: Get the artifact
               uses: dawidd6/action-download-artifact@v6
               with:
-                workflow: build.yml
+                workflow_search: true
+                run_id: ${{ inputs.run_id }}
                 name: docker_${{ inputs.run_id }}.snap
 
             - name: Publish to Store

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -33,7 +33,6 @@ jobs:
             - name: Get the artifact
               uses: dawidd6/action-download-artifact@v6
               with:
-                workflow_search: true
                 run_id: ${{ inputs.run_id }}
                 name: docker_${{ inputs.run_id }}.snap
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get the artifact
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: build.yml
+          workflow_search: true
           name: docker_[0-9]+.snap
           name_is_regexp: true
 


### PR DESCRIPTION
Remove `workflow` optional argument and set `workflow_search` to true, so the artifact can be matched based on the other given characteristics.