### PR TITLE
ci: Enable debugging of runner system resources

### DIFF
--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -30,6 +30,17 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Debug system resources
+              run: |
+
+                echo -e "\nChecking memory"
+                free -h
+                cat /proc/meminfo
+                echo -e "\nChecking disk"
+                df -h
+                cd / && du -sh *
+                exit -1
+
             - name: Get the artifact
               uses: dawidd6/action-download-artifact@v6
               with:


### PR DESCRIPTION
The `Branch` field on actions cannot be used to select from which branch a given manually triggered workflow will run, but rather to merely filter the runs.