### PR TITLE
Update to version 27.2.0

### DIFF
--- a/patches/engine/0002-snappy-apparmor-tweaks.patch
+++ b/patches/engine/0002-snappy-apparmor-tweaks.patch
@@ -17,7 +17,7 @@ index 277c853ebe..92e3872722 100644
  	"os"
  	"os/exec"
  	"path"
-+  "strconv"
++	"strconv"
  	"strings"
  	"text/template"
  )

--- a/patches/engine/0002-snappy-apparmor-tweaks.patch
+++ b/patches/engine/0002-snappy-apparmor-tweaks.patch
@@ -1,28 +1,27 @@
-From e9302d52e7cdc7b4b6364f08dfe15d52b920fff5 Mon Sep 17 00:00:00 2001
-From: Lucas Kanashiro <lucas.kanashiro@canonical.com>
-Date: Wed, 23 Aug 2023 18:58:55 -0300
+From 173566eebc60e3ed18ec595686688ad10f25388b Mon Sep 17 00:00:00 2001
+From: Lincoln Wallace <lincoln.wallace@canonical.com>
+Date: Wed, 28 Aug 2024 17:30:12 -0300
 Subject: [PATCH 2/5] snappy-apparmor-tweaks
 
+Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
 ---
- profiles/apparmor/apparmor.go | 18 ++++++++++++++++++
+ profiles/apparmor/apparmor.go | 17 +++++++++++++++++
  profiles/apparmor/template.go |  8 ++++++++
- 2 files changed, 26 insertions(+)
+ 2 files changed, 25 insertions(+)
 
 diff --git a/profiles/apparmor/apparmor.go b/profiles/apparmor/apparmor.go
-index d0f2361605..5a0a371d9b 100644
+index 277c853ebe..92e3872722 100644
 --- a/profiles/apparmor/apparmor.go
 +++ b/profiles/apparmor/apparmor.go
-@@ -7,7 +7,9 @@ import (
- 	"bufio"
- 	"io"
+@@ -9,6 +9,7 @@ import (
  	"os"
-+	"os/exec"
+ 	"os/exec"
  	"path"
-+	"strconv"
++  "strconv"
  	"strings"
  	"text/template"
- 
-@@ -27,6 +29,8 @@ type profileData struct {
+ )
+@@ -26,6 +27,8 @@ type profileData struct {
  	Imports []string
  	// InnerImports defines the apparmor functions to import in the profile.
  	InnerImports []string
@@ -31,7 +30,7 @@ index d0f2361605..5a0a371d9b 100644
  }
  
  // generateDefault creates an apparmor profile from ProfileData.
-@@ -46,6 +50,20 @@ func (p *profileData) generateDefault(out io.Writer) error {
+@@ -45,6 +48,20 @@ func (p *profileData) generateDefault(out io.Writer) error {
  		p.InnerImports = append(p.InnerImports, "#include <abstractions/base>")
  	}
  
@@ -53,10 +52,10 @@ index d0f2361605..5a0a371d9b 100644
  }
  
 diff --git a/profiles/apparmor/template.go b/profiles/apparmor/template.go
-index 5dcf35bf45..c9bae7187d 100644
+index 8dbc1b6102..c908b98999 100644
 --- a/profiles/apparmor/template.go
 +++ b/profiles/apparmor/template.go
-@@ -51,5 +51,13 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
+@@ -55,5 +55,13 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
  
    # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
    ptrace (trace,read,tracedby,readby) peer={{.Name}},
@@ -71,5 +70,5 @@ index 5dcf35bf45..c9bae7187d 100644
  }
  `
 -- 
-2.25.1
+2.43.0
 

--- a/patches/engine/0003-snappy-buildkit-git-environ.patch
+++ b/patches/engine/0003-snappy-buildkit-git-environ.patch
@@ -1,26 +1,27 @@
-From 9d87c45c50ebf6a5353e81f147a1c575d6e35f14 Mon Sep 17 00:00:00 2001
-From: Lucas Kanashiro <lucas.kanashiro@canonical.com>
-Date: Wed, 23 Aug 2023 18:59:37 -0300
-Subject: [PATCH 3/5] snappy-buildkit-git-environ
+From 65d421326d7edf6a96ce7b62d0c216d1b59e6509 Mon Sep 17 00:00:00 2001
+From: Lincoln Wallace <lincoln.wallace@canonical.com>
+Date: Fri, 30 Aug 2024 11:52:32 -0300
+Subject: [PATCH 3/5] snappy buildkit git environ
 
+Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
 ---
- vendor/github.com/moby/buildkit/source/git/gitsource.go | 3 +++
+ vendor/github.com/moby/buildkit/util/gitutil/git_cli.go | 3 +++
  1 file changed, 3 insertions(+)
 
-diff --git a/vendor/github.com/moby/buildkit/source/git/gitsource.go b/vendor/github.com/moby/buildkit/source/git/gitsource.go
-index dd35fe55f7..c811c09ead 100644
---- a/vendor/github.com/moby/buildkit/source/git/gitsource.go
-+++ b/vendor/github.com/moby/buildkit/source/git/gitsource.go
-@@ -666,6 +666,9 @@ func git(ctx context.Context, dir, sshAuthSock, knownHosts string, args ...strin
- 		cmd.Stderr = io.MultiWriter(stderr, errbuf)
+diff --git a/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go b/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go
+index 5c35f9365b..b0e0fb3aef 100644
+--- a/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go
++++ b/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go
+@@ -183,6 +183,9 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
+ 
  		cmd.Env = []string{
  			"PATH=" + os.Getenv("PATH"),
 +			"LD_LIBRARY_PATH=" + os.Getenv("LD_LIBRARY_PATH"),
-+                       "GIT_EXEC_PATH=" + os.Getenv("GIT_EXEC_PATH"),
-+                       "GIT_TEMPLATE_DIR=" + os.Getenv("GIT_TEMPLATE_DIR"),
++			"GIT_EXEC_PATH=" + os.Getenv("GIT_EXEC_PATH"),
++			"GIT_TEMPLATE_DIR=" + os.Getenv("GIT_TEMPLATE_DIR"),
  			"GIT_TERMINAL_PROMPT=0",
- 			"GIT_SSH_COMMAND=" + getGitSSHCommand(knownHosts),
+ 			"GIT_SSH_COMMAND=" + getGitSSHCommand(cli.sshKnownHosts),
  			//	"GIT_TRACE=1",
 -- 
-2.25.1
+2.43.0
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -336,7 +336,7 @@ parts:
   buildx:
     plugin: nil
     source: https://github.com/docker/buildx.git
-    # https://github.com/moby/moby/releases/tag/v27.1.0
+    # https://github.com/moby/moby/blob/v27.2.0/Dockerfile#L15
     source-tag: v0.16.1
     source-depth: 1
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: docker
 #title: Docker
-version: '24.0.5'
+version: '27.2.0'
 summary: Docker container runtime
 description: |
   Build and run container images with Docker.
@@ -168,7 +168,7 @@ parts:
   engine:
     plugin: make
     source: https://github.com/moby/moby.git
-    source-tag: v24.0.5
+    source-tag: v27.2.0
     source-depth: 1
     override-build: |
       $CRAFT_STAGE/patches/patch.sh
@@ -191,8 +191,8 @@ parts:
       install -T bundles/dynbinary-daemon/dockerd "$CRAFT_PART_INSTALL/bin/dockerd"
       # install docker-proxy previously provided by libnetwork part
       install -T bundles/dynbinary-daemon/docker-proxy "$CRAFT_PART_INSTALL/bin/docker-proxy"
-    # https://github.com/moby/moby/blob/v24.0.5/Dockerfile.simple (Docker-supported Go version for Engine)
-    build-snaps: &go ['go/1.20/stable']
+    # https://github.com/moby/moby/blob/v27.2.0/Dockerfile#L3 (Docker-supported Go version for Engine)
+    build-snaps: &go ['go/1.21/stable']
     # we get weird behavior if we mix/match Go versions throughout this one snapcraft.yml, so we use a YAML reference here to ensure we're always consistent throughout
     after: [wrapper-scripts]
     build-packages:
@@ -215,8 +215,8 @@ parts:
   containerd:
     plugin: make
     source: https://github.com/containerd/containerd.git
-    # from https://github.com/moby/moby/releases/tag/v24.0.5
-    source-tag: v1.6.21
+    # from https://github.com/moby/moby/blob/v27.2.0/Dockerfile#L199
+    source-tag: v1.7.21
     source-depth: 1
     override-build: |
       make GIT_COMMIT= GIT_BRANCH= LDFLAGS=
@@ -232,8 +232,8 @@ parts:
   runc:
     plugin: make
     source: https://github.com/opencontainers/runc.git
-    # from https://github.com/moby/moby/releases/tag/v24.0.5
-    source-tag: v1.1.12
+    # from https://github.com/moby/moby/blob/v27.2.0/Dockerfile#L290
+    source-tag: v1.1.13
     source-depth: 1
     override-build: |
       make BUILDTAGS='seccomp apparmor selinux' COMMIT=
@@ -295,7 +295,7 @@ parts:
     plugin: cmake
     source: https://github.com/krallin/tini.git
     source-type: git
-    # from https://github.com/moby/moby/blob/v24.0.5/hack/dockerfile/install/tini.installer
+    # from https://github.com/moby/moby/blob/v27.2.0/Dockerfile#L325
     source-tag: v0.19.0
     source-depth: 1
     organize:
@@ -309,7 +309,7 @@ parts:
     plugin: make
     build-snaps: *go
     source: https://github.com/docker/cli.git
-    source-tag: v24.0.5
+    source-tag: v27.2.0
     source-depth: 1
     override-build: |
       # docker build specific environment variables
@@ -336,8 +336,8 @@ parts:
   buildx:
     plugin: nil
     source: https://github.com/docker/buildx.git
-    # https://github.com/moby/moby/releases/tag/v24.0.5
-    source-tag: v0.11.2
+    # https://github.com/moby/moby/releases/tag/v27.1.0
+    source-tag: v0.16.1
     source-depth: 1
     override-build: |
       export DESTDIR="$CRAFT_PART_INSTALL/usr/libexec/docker/cli-plugins"


### PR DESCRIPTION
- Rewrote the `snappy-apparmor-tweaks` patch to ensure it applies correctly.
- Rewrote the `snappy-buildkit-git-environ` patch to ensure it applies correctly.
- Updated Go from version **1.20** to **1.21**.
- Updated Moby from version **v24.0.5** to **v27.2.0**.
- Updated containerd from version **v1.6.21** to **v1.7.21**.
- Updated runc from version **v1.1.12** to **v1.1.13.**
- closes #167.