### PR TITLE
fix: Remove passthrough for assumes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,11 +34,8 @@ grade: stable
 
 base: core22
 confinement: strict
-
-# Using passthrough until LP#2019931 is fixed
-passthrough:
-  assumes:
-    - snapd2.59.1
+assumes:
+  - snapd2.59.1
 
 layout:
   /etc/docker:


### PR DESCRIPTION
* The bug [LP#2019931](https://bugs.launchpad.net/snapcraft/+bug/2019931) is fixed since `Snapcraft 7.3.2`, so the use of passthrough it's not necessary anymore.
* closes #142
* Revert #134