### PR TITLE
fix: Snapcraft env related warnings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,9 +49,9 @@ environment:
   GIT_EXEC_PATH: "$SNAP/usr/lib/git-core"
   GIT_TEMPLATE_DIR: "$SNAP/usr/share/git-core/templates"
   # For nvidia support #
-  LD_LIBRARY_PATH:    $SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET}:${SNAP}/lib/:${SNAP}/lib/${CRAFT_ARCH_TRIPLET}:${SNAP}/usr/lib/:${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET}
-  LIBGL_DRIVERS_PATH: $SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET}/dri
-  LIBVA_DRIVERS_PATH: $SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET}/dri
+  LD_LIBRARY_PATH:    $SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${SNAP}/lib/:${SNAP}/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${SNAP}/usr/lib/:${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}
+  LIBGL_DRIVERS_PATH: $SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
+  LIBVA_DRIVERS_PATH: $SNAP/graphics/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/dri
   # nvidia-container-runtime can only set alternative config directory via XDG_CONFIG_HOME #
   XDG_CONFIG_HOME: $SNAP_DATA/etc
 
@@ -248,8 +248,8 @@ parts:
     source-tag: v1.15.0
     source-depth: 1
     override-pull: &arch-restrict |
-      [ "${CRAFT_TARGET_ARCH}" != "amd64" ] && \
-        [ "${CRAFT_TARGET_ARCH}" != "arm64" ] && \
+      [ "${CRAFT_ARCH_BUILD_FOR}" != "amd64" ] && \
+        [ "${CRAFT_ARCH_BUILD_FOR}" != "arm64" ] && \
         exit 0
       [ "${CRAFT_STEP_NAME}" = "BUILD" ] && $CRAFT_STAGE/patches/patch.sh
       craftctl default
@@ -283,10 +283,10 @@ parts:
     # Paths taken from upstream packaging #
     organize:
       usr/local/bin/nvidia-container-cli: usr/bin/nvidia-container-cli
-      usr/local/lib: usr/lib/${CRAFT_ARCH_TRIPLET}/
+      usr/local/lib: usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
     prime:
       - usr/bin/nvidia-container-cli*
-      - usr/lib/${CRAFT_ARCH_TRIPLET}/libnvidia-container*.so*
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libnvidia-container*.so*
 
   tini:
     plugin: cmake


### PR DESCRIPTION
Fix Warnings related to Snapcraft environment variables during building of snap:

```
CRAFT_ARCH_TRIPLET is deprecated, use CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}
CRAFT_ARCH_TRIPLET is deprecated, use CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}
CRAFT_ARCH_TRIPLET is deprecated, use CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
CRAFT_ARCH_TRIPLET is deprecated, use CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}
CRAFT_ARCH_TRIPLET is deprecated, use CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}
```

As recommended on: https://snapcraft.io/docs/parts-environment-variables