### PR TITLE
ci: Release on edge the latest version every two weeks

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,6 +1,9 @@
 name: Smoke Test
 
 on:
+  schedule:
+    # Runs at midnight (00:00) on Monday, every two weeks
+    - cron: "0 0 */14 * *"
   push:
     branches: [ main ]
   pull_request:
@@ -19,6 +22,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Fetch Newest version if running on schedule
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+
+          sudo apt update
+          sudo apt install -y curl
+          sudo snap install yq
+          # Running upgrade script
+          ./.github/workflows/upgrade.sh
+
+      # Upload snapcraft manifest file for reproductive builds
+      # in case of running from the scheduled trigger
+      - name: Upload snap manifest file
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapcraft.yaml
+          path: snap/snapcraft.yaml
+
       - name: Build
         uses: snapcore/action-build@v1
         id: snapcraft
@@ -30,6 +52,15 @@ jobs:
         with:
           name: docker_${{ github.run_id}}.snap
           path: ${{ steps.snapcraft.outputs.snap }}
+
+      - name: Publish snap to edge
+        uses: snapcore/action-publish@v1
+        if: ${{ github.event_name == 'schedule' }}
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
+        with:
+          snap: ${{ steps.snapcraft.outputs.snap }}
+          release: latest/edge
 
   smoke-test:
     needs: build
@@ -159,3 +190,23 @@ jobs:
           sudo DOCKER_BUILDKIT=1 docker build --pull -t tianon/gosleep https://github.com/tianon/gosleep.git
           sudo docker run --rm tianon/gosleep gosleep --help
           sudo docker image rm tianon/gosleep
+
+  promote-beta:
+    name: Promote to Beta
+    # Only promote if it's a scheduled event
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    needs: smoke-test
+    steps:
+      - name: Install Snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+          echo /snap/bin >> $GITHUB_PATH
+        shell: bash
+
+      - name: Promote Snap
+        env: # Workaround for https://github.com/snapcore/snapcraft/issues/4439
+          SNAPCRAFT_HAS_TTY: "true"
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
+        run: |
+          yes | snapcraft promote $SNAP_NAME --from-channel latest/edge --to-channel latest/beta

--- a/.github/workflows/upgrade.sh
+++ b/.github/workflows/upgrade.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -eux
+
+fetch_latest(){
+  # Fetch latest version from Github API
+  #  NOTE: It uses the index number 2 instead of 0 because on moby
+  #  there are the tags xdocs-v1.10-28-mar-2016 and xdocs-v1.10-09-05-2016
+  #  being listed first
+ LATEST=$(curl -s "https://api.github.com/repos/moby/moby/tags" | jq -r '.[2].name')
+}
+
+# Validate the version format
+validate_version(){
+  # Original simplified RegEx:
+  # v\d+.\d+.\d+\-*(rc.\d|rc\d|beta.\d)*
+  # By analysing the last tags on github.com/moby/moby/tags
+  # of last 3 years (since 2021).
+  if [[ "$LATEST" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]|rc[0-9]|beta\.[0-9])?$ ]]; then
+    echo "$LATEST matches the regex."
+  else
+    echo "Version doesn't match known pattern."
+    exit 1
+  fi
+}
+
+main(){
+
+  fetch_latest
+
+  validate_version
+
+  SNAP_VERSION=${LATEST#v}
+  echo -e "New snap version $SNAP_VERSION"
+
+  echo "The latest version of moby is: $LATEST"
+
+  # Fetch the Dockerfile
+  dockerfile=$(curl -s "https://raw.githubusercontent.com/moby/moby/refs/tags/$LATEST/Dockerfile")
+
+  # Declare variables and their corresponding regex patterns
+  declare -A variables=(
+    [GO_VERSION]='^ARG GO_VERSION='
+    [CONTAINERD_VERSION]='^ARG CONTAINERD_VERSION='
+    [RUNC_VERSION]='^ARG RUNC_VERSION='
+    [TINI_VERSION]='^ARG TINI_VERSION='
+    [DOCKERCLI_VERSION]='^ARG DOCKERCLI_VERSION='
+    [BUILDX_VERSION]='^ARG BUILDX_VERSION='
+    [COMPOSE_VERSION]='^ARG COMPOSE_VERSION='
+  )
+
+  # Extract versions using a loop
+  for var in "${!variables[@]}"; do
+    value=$(echo "$dockerfile" | awk -F= "/${variables[$var]}/ {print \$2}")
+
+    # Handle special cases: GO_VERSION and BUILDX_VERSION
+    if [[ "$var" == "GO_VERSION" ]]; then
+      # for GO_VERSION Extract major.minor
+      value=$(echo "$value" | awk -F. '{print $1 "." $2}')
+    elif [[ "$var" == "BUILDX_VERSION" && $value != v* ]]; then
+      value="v$value" # Prepend 'v' if missing
+    fi
+
+    declare "$var=$value"
+    echo "$var: ${!var}"
+  done
+
+  # Define the path to the YAML file
+  yaml_file="snap/snapcraft.yaml"
+
+  # Replace the `version:` field with the value of $SNAP_VERSION
+  yq -i ".version = \"$SNAP_VERSION\"" "$yaml_file"
+
+  # Replace fields in YAML using a loop
+  declare -A yaml_updates=(
+    [engine.source-tag]=$LATEST
+    [containerd.source-tag]=$CONTAINERD_VERSION
+    [runc.source-tag]=$RUNC_VERSION
+    [tini.source-tag]=$TINI_VERSION
+    [docker-cli.source-tag]=$DOCKERCLI_VERSION
+    [buildx.source-tag]=$BUILDX_VERSION
+    [compose-v2.source-tag]=$COMPOSE_VERSION
+  )
+
+  for part in "${!yaml_updates[@]}"; do
+    yq -i ".parts.${part} = \"${yaml_updates[$part]}\"" "$yaml_file"
+  done
+
+  # Replace `build-snaps` for `engine` with $GO_VERSION
+  yq -i '.parts.engine."build-snaps"[0] |= sub("[0-9]+\.[0-9]+", "'"$GO_VERSION"'")' "$yaml_file"
+
+  echo "YAML file updated successfully."
+
+}
+
+main


### PR DESCRIPTION
If the smoke tests passes, it releases to `beta`.

- Depends on: https://github.com/canonical/docker-snap/pull/199