### PR TITLE
Fix Testflinger attachment path

### DIFF
--- a/.github/workflows/testflinger/nvidia-job.yaml
+++ b/.github/workflows/testflinger/nvidia-job.yaml
@@ -9,7 +9,7 @@ test_data:
 
   # Copy files from the GH runner to the Testflinger Agent
   attachments:
-    - local: ".github/workflows/testflinger/scripts"
+    - local: "/.github/workflows/testflinger/scripts"
       agent: "scripts"
 
   # Run commands on the Testflinger Agent

--- a/.github/workflows/testflinger/nvidia-job.yaml
+++ b/.github/workflows/testflinger/nvidia-job.yaml
@@ -9,7 +9,7 @@ test_data:
 
   # Copy files from the GH runner to the Testflinger Agent
   attachments:
-    - local: "/.github/workflows/testflinger/scripts"
+    - local: "scripts"
       agent: "scripts"
 
   # Run commands on the Testflinger Agent


### PR DESCRIPTION
The default behavior has changed in https://github.com/canonical/testflinger/pull/374, making the attachment path relative to the Testflinger job.