### PR TITLE
fix: logic inconsistency for `publish` input on nvidia-test workflow

### DIFF
--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           TESTFLINGER_DIR: .github/workflows/testflinger
           JOB_QUEUE: docker-nvidia
-          SNAP_CHANNEL: latest/edge/runid-${{ inputs.run_id }}
+          SNAP_CHANNEL: ${{ inputs.publish == 'true' && 'latest/edge/runid-' + inputs.run_id || 'latest/edge' }}
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
The use of `$SNAP_CHANNEL` as `latest/edge/runid-<RUN_ID>` only makes sense if the checkbox to `publish` is marked as true.

If not, it means that it needs to run against `latest/edge` but there is no logic handling it and the workflow fails with the error:
```
 error: requested a non-existing branch on latest/edge for snap "docker":
```
as shown here:
https://github.com/canonical/docker-snap/actions/runs/12631899123/job/35194514402#step:5:1469