### PR TITLE
ci: add Ubuntu 20.04 and 24.04 to test runners

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -89,6 +89,7 @@ jobs:
           sudo snap connect docker:network-control :network-control
           sudo snap connect docker:support :docker-support
           sudo snap connect docker:privileged :docker-support
+          sudo snap connect docker:log-observe
 
           sudo snap stop --disable docker.dockerd # for good measure
           sleep 1

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -56,9 +56,6 @@ jobs:
 
       - name: refresh snapd
         run: |
-          # It seems that installing the deb version of snapd wasn't enought
-          # to have the snapd snap present (or at least active)
-          # sudo snap install hello-world
           sudo snap install snapd
           sudo snap refresh snapd
           sudo snap list

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,7 +33,7 @@ jobs:
 
   smoke-test:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,16 +59,16 @@ jobs:
           sudo rm -rf /var/lib/docker /etc/docker /run/docker* /var/lib/containerd /run/containerd*
           sudo ip link delete docker0 || :
 
-          # sudo apt update
+          sudo apt update
           # sudo apt install -y snapd
-          # sudo snap refresh
+          sudo snap refresh
 
           # It seems that installing the deb version of snapd wasn't enought
           # to have the snapd snap present (or at least active)
           sudo snap install hello-world
           sudo snap list
 
-          # sudo snap refresh --channel beta snapd
+          sudo snap refresh --channel beta snapd
 
       - name: Install
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -34,6 +34,7 @@ jobs:
   smoke-test:
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -48,6 +48,25 @@ jobs:
       #   with:
       #     wait-timeout-minutes: 3
 
+      - name: Prep
+        run: |
+          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+
+          # TODO figure out a better way to get Go and friends out of our path than dropping a nuke
+          sudo rm -rf /opt/hostedtoolcache/*
+
+          sudo apt-get purge --auto-remove -y 'docker.*' 'containerd.*' 'moby.*' 'runc.*'
+          sudo rm -rf /var/lib/docker /etc/docker /run/docker* /var/lib/containerd /run/containerd*
+          sudo ip link delete docker0 || :
+
+      - name: refresh snapd
+        run: |
+          # It seems that installing the deb version of snapd wasn't enought
+          # to have the snapd snap present (or at least active)
+          sudo snap install hello-world
+          sudo snap refresh snapd
+          sudo snap list
+
       - name: Collect snap environment info
         run: |
 
@@ -62,28 +81,6 @@ jobs:
 
           # Check avaible sandbox-features
           sudo snap debug sandbox-features
-
-      - name: Prep
-        run: |
-          # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
-
-          # TODO figure out a better way to get Go and friends out of our path than dropping a nuke
-          sudo rm -rf /opt/hostedtoolcache/*
-
-          sudo apt-get purge --auto-remove -y 'docker.*' 'containerd.*' 'moby.*' 'runc.*'
-          sudo rm -rf /var/lib/docker /etc/docker /run/docker* /var/lib/containerd /run/containerd*
-          sudo ip link delete docker0 || :
-
-          sudo apt update
-          # sudo apt install -y snapd
-          sudo snap refresh
-
-          # It seems that installing the deb version of snapd wasn't enought
-          # to have the snapd snap present (or at least active)
-          sudo snap install hello-world
-          sudo snap list
-
-          # sudo snap refresh --channel beta snapd
 
       - name: Install
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           name: docker_${{ github.run_id }}.snap
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          wait-timeout-minutes: 3
+
       - name: Prep
         run: |
           # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,7 +33,7 @@ jobs:
 
   smoke-test:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
           sudo snap install hello-world
           sudo snap list
 
-          sudo snap refresh --channel beta snapd
+          # sudo snap refresh --channel beta snapd
 
       - name: Install
         run: |
@@ -89,6 +89,8 @@ jobs:
           sudo snap connect docker:network-control :network-control
           sudo snap connect docker:support :docker-support
           sudo snap connect docker:privileged :docker-support
+
+          # Trying to fix by connecting log-observe
           sudo snap connect docker:log-observe
 
           sudo snap stop --disable docker.dockerd # for good measure

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,7 +33,7 @@ jobs:
 
   smoke-test:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -48,6 +48,21 @@ jobs:
       #   with:
       #     wait-timeout-minutes: 3
 
+      - name: Collect snap environment info
+        run: |
+
+          # System and snapd data
+          snap version
+
+          # Check how snapd is installed
+          sudo snap debug execution snap
+
+          # Check apparmor abi version
+          sudo snap debug execution apparmor
+
+          # Check avaible sandbox-features
+          sudo snap debug sandbox-features
+
       - name: Prep
         run: |
           # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -43,10 +43,10 @@ jobs:
         with:
           name: docker_${{ github.run_id }}.snap
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          wait-timeout-minutes: 3
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
+      #   with:
+      #     wait-timeout-minutes: 3
 
       - name: Prep
         run: |
@@ -59,9 +59,14 @@ jobs:
           sudo rm -rf /var/lib/docker /etc/docker /run/docker* /var/lib/containerd /run/containerd*
           sudo ip link delete docker0 || :
 
-          sudo apt update
-          sudo apt install -y snapd
-          sudo snap refresh
+          # sudo apt update
+          # sudo apt install -y snapd
+          # sudo snap refresh
+
+          # It seems that installing the deb version of snapd wasn't enought
+          # to have the snapd snap present (or at least active)
+          sudo snap install hello-world
+
           sudo snap refresh --channel beta snapd
           sudo snap list
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -66,9 +66,9 @@ jobs:
           # It seems that installing the deb version of snapd wasn't enought
           # to have the snapd snap present (or at least active)
           sudo snap install hello-world
-
-          sudo snap refresh --channel beta snapd
           sudo snap list
+
+          # sudo snap refresh --channel beta snapd
 
       - name: Install
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -54,10 +54,10 @@ jobs:
           sudo rm -rf /var/lib/docker /etc/docker /run/docker* /var/lib/containerd /run/containerd*
           sudo ip link delete docker0 || :
 
-      - name: refresh snapd
+      # The image comes with a slightly outdated snapd Debian package
+      - name: Install snapd as a snap
         run: |
           sudo snap install snapd
-          sudo snap refresh snapd
           sudo snap list
 
       - name: Collect snap environment info
@@ -72,7 +72,7 @@ jobs:
           # Check apparmor abi version
           sudo snap debug execution apparmor
 
-          # Check avaible sandbox-features
+          # Check available sandbox-features
           sudo snap debug sandbox-features
 
       - name: Install

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -67,17 +67,22 @@ jobs:
       - name: Collect snap environment info
         run: |
 
+          # These commands shouldn't cause workflow failure
+          set +e
+
           # System and snapd data
-          snap version || true
+          snap version
 
           # Check how snapd is installed
-          sudo snap debug execution snap || true
+          sudo snap debug execution snap
 
           # Check apparmor abi version
-          sudo snap debug execution apparmor || true
+          sudo snap debug execution apparmor
 
           # Check available sandbox-features
-          sudo snap debug sandbox-features || true
+          sudo snap debug sandbox-features
+
+          set -e
 
       - name: Install
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -68,16 +68,16 @@ jobs:
         run: |
 
           # System and snapd data
-          snap version
+          snap version || true
 
           # Check how snapd is installed
-          sudo snap debug execution snap
+          sudo snap debug execution snap || true
 
           # Check apparmor abi version
-          sudo snap debug execution apparmor
+          sudo snap debug execution apparmor || true
 
           # Check available sandbox-features
-          sudo snap debug sandbox-features
+          sudo snap debug sandbox-features || true
 
       - name: Install
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -43,11 +43,6 @@ jobs:
         with:
           name: docker_${{ github.run_id }}.snap
 
-      # - name: Setup upterm session
-      #   uses: lhotari/action-upterm@v1
-      #   with:
-      #     wait-timeout-minutes: 3
-
       - name: Prep
         run: |
           # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
@@ -63,7 +58,7 @@ jobs:
         run: |
           # It seems that installing the deb version of snapd wasn't enought
           # to have the snapd snap present (or at least active)
-          sudo snap install hello-world
+          # sudo snap install hello-world
           sudo snap install snapd
           sudo snap refresh snapd
           sudo snap list
@@ -103,9 +98,6 @@ jobs:
           sudo snap connect docker:support :docker-support
           sudo snap connect docker:privileged :docker-support
 
-          # Trying to fix by connecting log-observe
-          sudo snap connect docker:log-observe
-
           sudo snap stop --disable docker.dockerd # for good measure
           sleep 1
           sudo snap start --enable docker.dockerd
@@ -135,14 +127,16 @@ jobs:
       - name: Hello World
         run: sudo docker run --rm hello-world
 
-      - name: Hello World (journald)
-        run: |
-          trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
-          expectedOutput="testing-journald-log-driver-$RANDOM-$RANDOM"
-          sudo docker run --name test-journald --log-driver journald bash -c 'echo "$@"' -- "$expectedOutput"
-          actualOutput="$(sudo docker logs test-journald)"
-          [ "$actualOutput" = "$expectedOutput" ]
-          docker rm test-journald
+      # NOTE: deactivating test for now since journald is broken for docker-snap on Noble
+        # see: https://github.com/canonical/docker-snap/issues/181
+      # - name: Hello World (journald)
+      #   run: |
+      #     trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
+      #     expectedOutput="testing-journald-log-driver-$RANDOM-$RANDOM"
+      #     sudo docker run --name test-journald --log-driver journald bash -c 'echo "$@"' -- "$expectedOutput"
+      #     actualOutput="$(sudo docker logs test-journald)"
+      #     [ "$actualOutput" = "$expectedOutput" ]
+      #     docker rm test-journald
 
       - name: Hello World (init)
         run: sudo docker run --rm --init hello-world

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,7 +33,10 @@ jobs:
 
   smoke-test:
     needs: build
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -64,6 +64,7 @@ jobs:
           # It seems that installing the deb version of snapd wasn't enought
           # to have the snapd snap present (or at least active)
           sudo snap install hello-world
+          sudo snap install snapd
           sudo snap refresh snapd
           sudo snap list
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -133,16 +133,18 @@ jobs:
       - name: Hello World
         run: sudo docker run --rm hello-world
 
-      # NOTE: deactivating test for now since journald is broken for docker-snap on Noble
+
+      - name: Hello World (journald)
+        # NOTE: Test temporarily disabled on Noble due to a known issue with journald on Noble systems affecting docker-snap.
         # see: https://github.com/canonical/docker-snap/issues/181
-      # - name: Hello World (journald)
-      #   run: |
-      #     trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
-      #     expectedOutput="testing-journald-log-driver-$RANDOM-$RANDOM"
-      #     sudo docker run --name test-journald --log-driver journald bash -c 'echo "$@"' -- "$expectedOutput"
-      #     actualOutput="$(sudo docker logs test-journald)"
-      #     [ "$actualOutput" = "$expectedOutput" ]
-      #     docker rm test-journald
+        if: ${{ matrix.os != 'ubuntu-24.04' }}
+        run: |
+          trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
+          expectedOutput="testing-journald-log-driver-$RANDOM-$RANDOM"
+          sudo docker run --name test-journald --log-driver journald bash -c 'echo "$@"' -- "$expectedOutput"
+          actualOutput="$(sudo docker logs test-journald)"
+          [ "$actualOutput" = "$expectedOutput" ]
+          docker rm test-journald
 
       - name: Hello World (init)
         run: sudo docker run --rm --init hello-world


### PR DESCRIPTION
- Related to https://github.com/canonical/docker-snap/issues/181

