### PR TITLE
snap: add missing meta-data

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,6 +2,9 @@ name: docker
 #title: Docker
 version: '27.4.1'
 summary: Docker container runtime
+issues: https://github.com/canonical/docker-snap/issues
+source-code: https://github.com/canonical/docker-snap
+website: https://github.com/canonical/docker-snap
 description: |
   Build and run container images with Docker.
 


### PR DESCRIPTION
Add 'issues', 'source-code', and 'website' tags.
This allows to display the information with `snap info docker`.