### PR TITLE
Add manual connection command for the home interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,11 @@ Additional access is granted via [snap interfaces](https://snapcraft.io/docs/int
 Upon installation using the above command, the snap connects automatically to the following system interface slots:
 - [docker-support](https://snapcraft.io/docs/docker-support-interface)
 - [firewall-control](https://snapcraft.io/docs/firewall-control-interface)
-- [home](https://snapcraft.io/docs/home-interface)
+- [home](https://snapcraft.io/docs/home-interface) - only on classic/traditional distributions
 - [network](https://snapcraft.io/docs/network-interface)
 - [network-bind](https://snapcraft.io/docs/network-bind-interface)
 - [network-control](https://snapcraft.io/docs/network-control-interface)
 - [opengl](https://snapcraft.io/docs/opengl-interface)
-
 
 If you are using Ubuntu Core 16, connect the `docker:home` plug as it's not auto-connected by default:
 
@@ -182,6 +181,7 @@ sudo snap connect docker:support :docker-support
 sudo snap connect docker:firewall-control :firewall-control
 sudo snap connect docker:network-control :network-control
 sudo snap connect docker:docker-cli docker:docker-daemon
+sudo snap connect docker:home
 
 sudo snap disable docker
 sudo snap enable docker


### PR DESCRIPTION
The `home` interface does not auto-connect when installing an unsigned snap. 

```console
$ sudo snap install --dangerous ./docker_27.4.1_amd64.snap 
docker 27.4.1 installed

$ snap connections docker 
Interface         Plug                     Slot                                 Notes
content           -                        docker:config-ro                     -
content           -                        docker:docker-executables            -
content           -                        docker:docker-registry-certificates  -
content           docker:graphics-core22   -                                    -
docker            -                        docker:docker-daemon                 -
docker            docker:docker-cli        -                                    -
docker-support    docker:privileged        -                                    -
docker-support    docker:support           -                                    -
firewall-control  docker:firewall-control  -                                    -
home              docker:home              -                                    -
log-observe       docker:log-observe       -                                    -
network           docker:network           :network                             -
network-bind      docker:network-bind      :network-bind                        -
network-control   docker:network-control   -                                    -
opengl            docker:opengl            :opengl                              -
removable-media   docker:removable-media   -                                    -
```

See also https://github.com/canonical/docker-snap/issues/209#issuecomment-2577887883