### PR TITLE
docs: Remove snap description

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,39 +1,13 @@
 name: docker
-#title: Docker
 version: '27.4.1'
 summary: Docker container runtime
-description: |
-  Build and run container images with Docker.
-
-  **Usage**
-
-  * This build can only access files in the home directory. So Dockerfiles and all other files used in commands like `docker build`, `docker save` and `docker load` need to be in $HOME.
-  * You can change the configuration of this build by modifying the files in `/var/snap/docker/current/`.
-  * Additional certificates used by the Docker daemon to authenticate with registries need to be added in `/var/snap/docker/current/etc/docker/certs.d` (instead of `/etc/docker/certs.d`). This directory can be accessed by other snaps using the `docker-registry-certificates` content interface.
-  * Specifying the option `--security-opt="no-new-privileges=true"` with the `docker run` command (or the equivalent in docker-compose) will result in a failure of the container to start. This is due to an an underlying external constraint on AppArmor (see https://bugs.launchpad.net/snappy/+bug/1908448 for details).
-
-  **Running Docker as normal user**
-
-  By default, Docker is only accessible with root privileges (`sudo`). If you want to use docker as a regular user, you need to add your user to the `docker` group.
-
-      sudo addgroup --system docker
-      sudo adduser $USER docker
-      newgrp docker
-      sudo snap disable docker
-      sudo snap enable docker
-
-  **Warning:** if you add your user to the `docker` group, it will have similar power as the `root` user. For details on how this impacts security in your system, see https://docs.docker.com/engine/security/#docker-daemon-attack-surface
-
-  **Authors**
-
-  This snap is built by Canonical based on source code published by Docker, Inc. It is not endorsed or published by Docker, Inc.
-
-  Docker and the Docker logo are trademarks or registered trademarks of Docker, Inc. in the United States and/or other countries. Docker, Inc. and other parties may also have trademark rights in other terms used herein.
+description: Refer to https://snapcraft.io/docker
 license: (Apache-2.0 AND MIT AND GPL-2.0)
+
 grade: stable
+confinement: strict
 
 base: core22
-confinement: strict
 assumes:
   - snapd2.59.1
 


### PR DESCRIPTION
The snap's metadata is maintained on the Snap Store.

Removing the description in source to ease maintenance of the instructions and avoid confusion (#211).