### PR TITLE
CI: Run Nvidia workflow on UC22

### DIFF
--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -11,6 +11,13 @@ on:
         description: 'Run id number'
         required: true
         type: number
+      os_release:
+        description: 'Os release'
+        required: true
+        type: choice
+        options:
+          - core22-latest
+          - noble
       publish:
         description: 'Publish to Store'
         default: true
@@ -36,15 +43,11 @@ jobs:
                 release: latest/edge/runid-${{ inputs.run_id }}
 
     test:
-        strategy:
-          fail-fast: false
-          matrix:
-            os: [ noble, core22-latest]
         needs: publish
         if: ${{ always() && !failure() && !cancelled() }}
         runs-on: [self-hosted, testflinger]
         env:
-          OS_RELEASE: ${{ matrix.os }}
+          OS_RELEASE: ${{ inputs.os_release }}
           TESTFLINGER_DIR: .github/workflows/testflinger
           JOB_QUEUE: docker-nvidia
           SNAP_CHANNEL: latest/edge/runid-${{ inputs.run_id }}

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -36,10 +36,15 @@ jobs:
                 release: latest/edge/runid-${{ inputs.run_id }}
 
     test:
+        strategy:
+          fail-fast: false
+          matrix:
+            os: [ noble, core22-latest]
         needs: publish
         if: ${{ always() && !failure() && !cancelled() }}
         runs-on: [self-hosted, testflinger]
         env:
+          OS_RELEASE: ${{ matrix.os }}
           TESTFLINGER_DIR: .github/workflows/testflinger
           JOB_QUEUE: docker-nvidia
           SNAP_CHANNEL: latest/edge/runid-${{ inputs.run_id }}
@@ -49,6 +54,10 @@ jobs:
 
             - name: Create Testflinger job queue
               run: |
+                envsubst '$OS_RELEASE' \
+                  < $TESTFLINGER_DIR/nvidia-job.yaml \
+                  > $TESTFLINGER_DIR/nvidia-job.temp
+
                 envsubst '$JOB_QUEUE' \
                   < $TESTFLINGER_DIR/nvidia-job.yaml \
                   > $TESTFLINGER_DIR/nvidia-job.temp

--- a/.github/workflows/testflinger/nvidia-job.yaml
+++ b/.github/workflows/testflinger/nvidia-job.yaml
@@ -4,7 +4,7 @@ job_queue: $JOB_QUEUE
 global_timeout: 3600
 output_timeout: 1800
 provision_data:
-    distro: "noble"
+    distro: $OS_RELEASE
 test_data:
 
   # Copy files from the GH runner to the Testflinger Agent


### PR DESCRIPTION
Currently, the OS used on the Nvidia tests [is hardcoded](https://github.com/canonical/docker-snap/blob/7d5e826d6b6787cfa98ba9d803cdbf319003c942/.github/workflows/testflinger/nvidia-job.yaml#L7):

https://github.com/canonical/docker-snap/blob/7d5e826d6b6787cfa98ba9d803cdbf319003c942/.github/workflows/testflinger/nvidia-job.yaml#L7

However, we already have mechanisms in place to support testing on UC22 as well:

https://github.com/canonical/docker-snap/blob/7d5e826d6b6787cfa98ba9d803cdbf319003c942/.github/workflows/testflinger/scripts/setup.sh#L49-L63

This PR updates the workflow to include tests for UC22 alongside the existing tests for Noble by using a matrix configuration.