### PR TITLE
build(upgrade.sh): RegEx to match only commented URL pointing to moby Dockerfile

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -110,7 +110,7 @@ main() {
   yq -i '.parts.engine."build-snaps"[0] |= sub("[0-9]+\.[0-9]+", "'"$GO_VERSION"'")' "$yaml_file"
 
   # Replace the remaining comments
-  sed -i "s/$CURRENT/$LATEST/g" "$yaml_file"
+  sed -i "s/moby\/blob\/$CURRENT/moby\/blob\/$LATEST/g" "$yaml_file"
 
   echo "YAML file updated successfully."
 


### PR DESCRIPTION
This part of upgrade script:

https://github.com/canonical/docker-snap/blob/69554a091f95da4015a0f38dbb05d7dd937b151f/upgrade.sh#L113

It is designed to change the comments with URLs pointing to Dockerfile of Moby.

But it only looks for the tag version, that's why it was changing the version of other parts that matches the exact same version.

This change adds more context to the RegEx so it only matches the URLs on the comments.

[skip ci]