### PR TITLE
ci: upgrade CUDA Toolkit to 12.8

### DIFF
--- a/.github/workflows/testflinger/scripts/setup.sh
+++ b/.github/workflows/testflinger/scripts/setup.sh
@@ -33,7 +33,7 @@ setup_classic() {
   sudo dpkg -i cuda-keyring_1.1-1_all.deb
 
   apt_update
-  sudo apt-get -y install cuda-toolkit-12-5
+  sudo apt-get -y install cuda-toolkit-12-8
   sudo apt-get install -y nvidia-driver-555-open
   sudo apt-get install -y cuda-drivers-555
 


### PR DESCRIPTION
The latest `CUDA` toolkit version is 12.8.0 according to:

https://developer.nvidia.com/cuda-toolkit-archive