### PR TITLE
build: Set removable-media and opengl plugs only where is needed

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,12 +97,14 @@ apps:
       - docker-cli
       - network
       - home
+      - removable-media
 
   nvidia-container-toolkit:
     command: bin/nvidia-container-toolkit
     daemon: oneshot
     plugs:
       - graphics-core22
+      - removable-media
     before:
       - dockerd
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,8 +39,6 @@ plugs:
     privileged-containers: true
   docker-cli:
     interface: docker
-  opengl:
-  # For nvidia userspace libs support #
   graphics-core22:
     interface: content
     target: $SNAP/graphics
@@ -74,6 +72,8 @@ apps:
       - network
       - home
       - removable-media
+      # For nvidia userspace libs support #
+      - opengl
 
   dockerd:
     command: bin/dockerd-wrapper
@@ -88,6 +88,8 @@ apps:
       - support
       - graphics-core22
       - removable-media
+      # For nvidia userspace libs support #
+      - opengl
     slots:
       - docker-daemon
 
@@ -98,6 +100,8 @@ apps:
       - network
       - home
       - removable-media
+      # For nvidia userspace libs support #
+      - opengl
 
   nvidia-container-toolkit:
     command: bin/nvidia-container-toolkit
@@ -105,6 +109,8 @@ apps:
     plugs:
       - graphics-core22
       - removable-media
+      # For nvidia userspace libs support #
+      - opengl
     before:
       - dockerd
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,6 @@ environment:
 plugs:
   home:
     read: all
-  removable-media:
   support:
     interface: docker-support
   privileged:
@@ -88,6 +87,7 @@ apps:
       - privileged
       - support
       - graphics-core22
+      - removable-media
     slots:
       - docker-daemon
 


### PR DESCRIPTION
Fix  Snapcraft build warning:
```
Warning: implicit plug assignment in 'opengl' and 'removable-media'.
Plugs should be assigned to the app to which they apply, and not implicitly
assigned via the global 'plugs:' stanza which is intended for configuration only.
```

- Fixes: https://github.com/canonical/docker-snap/issues/183