### PR TITLE
feat: Add missing parameters for mounting overlayfs

### DIFF
--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -33,15 +33,27 @@ force_umount() {
 }
 
 dir="$(mktemp -d)"
+# overlay needs a writable upperdir, lowerdir, workdir and a merged mountpoint
+upper="$(mktemp -d)"
+lower="$(mktemp -d)"
+work="$(mktemp -d)"
+extra_fs_params=""
+
 trap "force_umount --no-mtab '$dir'; rm -rf '$dir'" EXIT
 # try mounting a few FS types to force the kernel to try loading modules
 for t in aufs overlay zfs; do
-	yolo mount --no-mtab -t "$t" /dev/null "$dir"
+	if [ "$t" = "overlay" ]; then
+  		extra_fs_params=$(echo -olowerdir="$lower",upperdir="$upper",workdir="$work")
+	fi
+	yolo mount --no-mtab -t "$t" /dev/null "$extra_fs_params" "$dir" 
 	force_umount --no-mtab "$dir"
+	extra_fs_params=""
 done
+
+
 # inside our snap, we can't "modprobe" for whatever reason (probably no access to the .ko files)
 # so this forces the kernel itself to "modprobe" for these filesystems so that the modules we need are available to Docker
-rm -rf "$dir"
+rm -rf "$dir" "$upper" "$lower" "$work"
 trap - EXIT
 
 # modify XDG_RUNTIME_DIR to be a snap writable dir underneath $SNAP_COMMON 

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -37,20 +37,17 @@ dir="$(mktemp -d)"
 upper="$(mktemp -d)"
 lower="$(mktemp -d)"
 work="$(mktemp -d)"
-extra_fs_params=""
 
 # inside our snap, we can't "modprobe" for whatever reason (probably no access to the .ko files)
 # so this forces the kernel itself to "modprobe" for these filesystems so that the modules we need are available to Docker
 trap "force_umount --no-mtab '$dir'; rm -rf '$dir'" EXIT
 # try mounting a few FS types to force the kernel to try loading modules
-for t in aufs overlay zfs; do
-	if [ "$t" = "overlay" ]; then
-  		extra_fs_params=$(echo -olowerdir="$lower",upperdir="$upper",workdir="$work")
-	fi
-	yolo mount --no-mtab -t "$t" /dev/null "$extra_fs_params" "$dir" 
-	force_umount --no-mtab "$dir"
-	extra_fs_params=""
-done
+yolo mount --no-mtab -t overlay /dev/null -olowerdir="$lower",upperdir="$upper",workdir="$work" "$dir" 
+force_umount --no-mtab "$dir"
+yolo mount --no-mtab -t aufs /dev/null "$extra_fs_params" "$dir" 
+force_umount --no-mtab "$dir"
+yolo mount --no-mtab -t zfs /dev/null "$extra_fs_params" "$dir" 
+force_umount --no-mtab "$dir"
 
 rm -rf "$dir" "$upper" "$lower" "$work"
 trap - EXIT

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -39,6 +39,8 @@ lower="$(mktemp -d)"
 work="$(mktemp -d)"
 extra_fs_params=""
 
+# inside our snap, we can't "modprobe" for whatever reason (probably no access to the .ko files)
+# so this forces the kernel itself to "modprobe" for these filesystems so that the modules we need are available to Docker
 trap "force_umount --no-mtab '$dir'; rm -rf '$dir'" EXIT
 # try mounting a few FS types to force the kernel to try loading modules
 for t in aufs overlay zfs; do
@@ -50,9 +52,6 @@ for t in aufs overlay zfs; do
 	extra_fs_params=""
 done
 
-
-# inside our snap, we can't "modprobe" for whatever reason (probably no access to the .ko files)
-# so this forces the kernel itself to "modprobe" for these filesystems so that the modules we need are available to Docker
 rm -rf "$dir" "$upper" "$lower" "$work"
 trap - EXIT
 

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -44,9 +44,9 @@ trap "force_umount --no-mtab '$dir'; rm -rf '$dir'" EXIT
 # try mounting a few FS types to force the kernel to try loading modules
 yolo mount --no-mtab -t overlay /dev/null -olowerdir="$lower",upperdir="$upper",workdir="$work" "$dir" 
 force_umount --no-mtab "$dir"
-yolo mount --no-mtab -t aufs /dev/null "$extra_fs_params" "$dir" 
+yolo mount --no-mtab -t aufs /dev/null "$dir" 
 force_umount --no-mtab "$dir"
-yolo mount --no-mtab -t zfs /dev/null "$extra_fs_params" "$dir" 
+yolo mount --no-mtab -t zfs /dev/null "$dir" 
 force_umount --no-mtab "$dir"
 
 rm -rf "$dir" "$upper" "$lower" "$work"

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -33,7 +33,7 @@ force_umount() {
 }
 
 dir="$(mktemp -d)"
-# overlay needs a writable upperdir, lowerdir, workdir and a merged mountpoint
+# overlayfs: https://docs.kernel.org/filesystems/overlayfs.html#directories
 upper="$(mktemp -d)"
 lower="$(mktemp -d)"
 work="$(mktemp -d)"


### PR DESCRIPTION
[According to the kernel documentation](https://docs.kernel.org/filesystems/overlayfs.html#directories), `overlayfs` needs the additional parameters to be mounted:

```bash
mount -t overlay overlay -olowerdir=/lower,upperdir=/upper,workdir=/work /merged
```
- Fixes: https://github.com/canonical/docker-snap/issues/205

## Testing

For test the changes, on an Ubuntu machine (preferable a clean install), build the snap then:
```console
# install the snap
ubuntu@dftd:~$ sudo snap install ./docker_27.5.1_amd64.snap --dangerous
docker 27.5.1 installed
ubuntu@dftd:~$

# Connect the interfaces
ubuntu@dftd:~$ sudo snap connect docker:privileged :docker-support
sudo snap connect docker:support :docker-support
sudo snap connect docker:firewall-control :firewall-control
sudo snap connect docker:network-control :network-control
sudo snap connect docker:docker-cli docker:docker-daemon
sudo snap connect docker:home

sudo snap disable docker
sudo snap enable docker
docker disabled
docker enabled
ubuntu@dftd:~$
ubuntu@dftd:~$ sudo dmesg | grep overlay
[   12.225567] evm: overlay not supported
ubuntu@dftd:~$
ubuntu@dftd:~$ sudo reboot now

# After reboot:

ubuntu@dftd:~$ snap list docker
Name    Version  Rev  Tracking  Publisher  Notes
docker  27.5.1   x1   -         -          -
ubuntu@dftd:~$ sudo dmesg | grep overlay
[   12.452295] evm: overlay not supported
ubuntu@dftd:~$
```

Note: The message `evm: overlay not supported` isn't related to this problem.


