### PR TITLE
feat: make Docker daemon data directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ Docker should function normally, with the following caveats:
 > Make sure to use a location that the snap has access, which is:
 > - Inside the $HOME directory;
 >
-> Then disable and re-enable the snap:
+> Then restart the dockerd service:
 > ```shell
-> sudo snap disable docker
-> sudo snap enable docker
+> sudo snap restart docker.dockerd
 > ```
 
 * All files that `docker` needs access to should live within your `$HOME` folder.

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ Docker should function normally, with the following caveats:
 >  
 > **Get the current value:**  
 > ```shell
-> sudo snap get docker data-dir
+> sudo snap get docker data-root
 > ```  
 >  
 > **Set a new location:**  
 > ```shell
-> sudo snap set docker data-dir=<new-directory>
+> sudo snap set docker data-root=<new-directory>
 > ```
 > Make sure to use a location that the snap has access, which is:
 > - Inside the $HOME directory;

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ Docker should function normally, with the following caveats:
 > ```
 > Make sure to use a location that the snap has access, which is:
 > - Inside the $HOME directory;
-> - On a removable driver inside of `/media`, `/run/media` or `/mnt` (needs [removable-media interface](https://snapcraft.io/docs/removable-media-interface) connected)
->     - The removable drives needs to be mounted as root, otherwise the dockerd service will fail with the error: `could not create or set daemon root permissions: <dir>: chown <dir>: operation not permitted`
+> - On a removable drive inside `/media`, `/run/media`, or `/mnt` (requires the [removable-media interface](https://snapcraft.io/docs/removable-media-interface) to be connected)  
+>   - The removable drive must be mounted as root; otherwise, the `dockerd` service will fail with the error:  
+>     `could not create or set daemon root permissions: <dir>: chown <dir>: operation not permitted`
 >
 > Then restart the dockerd service:
 > ```shell

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Docker should function normally, with the following caveats:
 > ```
 > Make sure to use a location that the snap has access, which is:
 > - Inside the $HOME directory;
+> - On a removable driver inside of `/media`, `/run/media` or `/mnt` (needs [removable-media interface](https://snapcraft.io/docs/removable-media-interface) connected)
+>     - The removable drives needs to be mounted as root, otherwise the dockerd service will fail with the error: `could not create or set daemon root permissions: <dir>: chown <dir>: operation not permitted`
 >
 > Then restart the dockerd service:
 > ```shell

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo snap get docker data-root
 ```shell
 sudo snap set docker data-root=<new-directory>
 ```
-Make sure to use a location that the snap has access, which is:
+Make sure to use a location that the snap has access to, which is:
 - Inside the `$HOME` directory;
 - Within a snap-writable area, as described in the [data locations documentation](https://snapcraft.io/docs/data-locations).
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ sudo snap set docker data-root=<new-directory>
 ```
 Make sure to use a location that the snap has access, which is:
 - Inside the `$HOME` directory;
-- On a removable drive, via the [removable-media interface](https://snapcraft.io/docs/removable-media-interface) interface:  
-  - The removable drive must be mounted as root; otherwise, the `dockerd` service will fail with the error:  
-    `could not create or set daemon root permissions: <dir>: chown <dir>: operation not permitted`
+- Within a snap-writable area, as described in the [data locations documentation](https://snapcraft.io/docs/data-locations).
 
 Then restart the dockerd service:
 ```shell

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Docker should function normally, with the following caveats:
 > ```
 > Make sure to use a location that the snap has access, which is:
 > - Inside the $HOME directory;
-> - On a removable driver inside of `/media`, `/run/media` or `/mnt` (needs [removable-media interface](https://snapcraft.io/docs/removable-media-interface) connected).
 >
 > Then disable and re-enable the snap:
 > ```shell

--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ sudo snap enable docker
 
 Docker should function normally, with the following caveats:
 
+> [!IMPORTANT]  
+> In the `docker` snap, the default location for the [data-root](https://docs.docker.com/engine/daemon/#daemon-data-directory) directory is `$SNAP_COMMON/var-lib-docker`, which maps to `/var/snap/docker/common/var-lib-docker` based on the [snap data locations](https://snapcraft.io/docs/data-locations#heading--system).  
+>  
+> You may want to change this because if the snap is removed, all Docker-related data (images, containers, volumes) will be deleted.  
+>  
+> To modify the default location, use [snap configuration options](https://snapcraft.io/docs/configuration-in-snaps):  
+>  
+> **Get the current value:**  
+> ```shell
+> sudo snap get docker data-dir
+> ```  
+>  
+> **Set a new location:**  
+> ```shell
+> sudo snap set docker data-dir=<new-directory>
+> ```
+> Make sure to use a location that the snap has access, which is:
+> - Inside the $HOME directory;
+> - On a removable driver inside of `/media`, `/run/media` or `/mnt` (needs [removable-media interface](https://snapcraft.io/docs/removable-media-interface) connected).
+>
+> Then disable and re-enable the snap:
+> ```shell
+> sudo snap disable docker
+> sudo snap enable docker
+> ```
+
 * All files that `docker` needs access to should live within your `$HOME` folder.
 
   * If you are using Ubuntu Core 16, you'll need to work within a subfolder of `$HOME` that is readable by root; see [#8](https://github.com/docker/docker-snap/issues/8).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,36 @@ If you are using Ubuntu Core 16, connect the `docker:home` plug as it's not auto
 sudo snap connect docker:home
 ```
 
+### Changing the data root directory
+
+In the `docker` snap, the default location for the [data-root](https://docs.docker.com/engine/daemon/#daemon-data-directory) directory is `$SNAP_COMMON/var-lib-docker`, which maps to `/var/snap/docker/common/var-lib-docker` based on the [snap data locations](https://snapcraft.io/docs/data-locations#heading--system).
+
+> [!WARNING]
+> By default, SnapD removes the snap's data locations and creates [snapshots](https://snapcraft.io/docs/snapshots) that serve as backup. 
+> Changing the root directory to a different path results in loss of snapshot functionalities, leaving you responsible for the management of those files.  
+  
+To modify the default location, use [snap configuration options](https://snapcraft.io/docs/configuration-in-snaps):  
+  
+**Get the current value:**  
+```shell
+sudo snap get docker data-root
+```  
+  
+**Set a new location:**  
+```shell
+sudo snap set docker data-root=<new-directory>
+```
+Make sure to use a location that the snap has access, which is:
+- Inside the `$HOME` directory;
+- On a removable drive, via the [removable-media interface](https://snapcraft.io/docs/removable-media-interface) interface:  
+  - The removable drive must be mounted as root; otherwise, the `dockerd` service will fail with the error:  
+    `could not create or set daemon root permissions: <dir>: chown <dir>: operation not permitted`
+
+Then restart the dockerd service:
+```shell
+sudo snap restart docker.dockerd
+```
+
 ### Running Docker as normal user
 
 By default, Docker is only accessible with root privileges (`sudo`). If you want to use docker as a regular user, you need to add your user to the `docker` group. This isn't possible on Ubuntu Core because it disallows the addition of users to system groups [[1](https://forum.snapcraft.io/t/adding-users-to-system-groups-on-ubuntu-core/20109), [2](https://github.com/snapcore/core20/issues/72)].
@@ -60,33 +90,6 @@ sudo snap enable docker
 ## Usage
 
 Docker should function normally, with the following caveats:
-
-> [!IMPORTANT]  
-> In the `docker` snap, the default location for the [data-root](https://docs.docker.com/engine/daemon/#daemon-data-directory) directory is `$SNAP_COMMON/var-lib-docker`, which maps to `/var/snap/docker/common/var-lib-docker` based on the [snap data locations](https://snapcraft.io/docs/data-locations#heading--system).  
->  
-> You may want to change this because if the snap is removed, all Docker-related data (images, containers, volumes) will be deleted.  
->  
-> To modify the default location, use [snap configuration options](https://snapcraft.io/docs/configuration-in-snaps):  
->  
-> **Get the current value:**  
-> ```shell
-> sudo snap get docker data-root
-> ```  
->  
-> **Set a new location:**  
-> ```shell
-> sudo snap set docker data-root=<new-directory>
-> ```
-> Make sure to use a location that the snap has access, which is:
-> - Inside the $HOME directory;
-> - On a removable drive inside `/media`, `/run/media`, or `/mnt` (requires the [removable-media interface](https://snapcraft.io/docs/removable-media-interface) to be connected)  
->   - The removable drive must be mounted as root; otherwise, the `dockerd` service will fail with the error:  
->     `could not create or set daemon root permissions: <dir>: chown <dir>: operation not permitted`
->
-> Then restart the dockerd service:
-> ```shell
-> sudo snap restart docker.dockerd
-> ```
 
 * All files that `docker` needs access to should live within your `$HOME` folder.
 

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -66,6 +66,12 @@ workaround_apparmor_profile_reload
 DATA_DIR="$(snapctl get data-dir)"
 data_dir="${DATA_DIR:-$DEFAULT_DATA_DIR}"
 
+# Avoiding the following error: 
+# msg="cleanup working directory in namespace" 
+# error="open <dir>/containerd/daemon/io.containerd.runtime.v2.task/moby: no such file or directory"
+# namespace=moby
+mkdir -p "$data_dir"/containerd/daemon/io.containerd.runtime.v2.task/moby
+
 exec dockerd \
 	--group "$default_socket_group" \
 	--exec-root="$run_dir" \

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -64,9 +64,6 @@ workaround_lp1606510
 workaround_apparmor_profile_reload
 
 data_root="$(snapctl get data-root)"
-data_root="${data_root:-$DEFAULT_DATA_ROOT}"
-# Feedback for the user in case the data-root is set to the default
-snapctl set data-root="$data_root"
 
 exec dockerd \
 	--group "$default_socket_group" \

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -63,19 +63,19 @@ workaround_lp1606510
 
 workaround_apparmor_profile_reload
 
-DATA_DIR="$(snapctl get data-dir)"
-data_dir="${DATA_DIR:-$DEFAULT_DATA_DIR}"
+data_root="$(snapctl get data-root)"
+data_root="${data_root:-$DEFAULT_DATA_ROOT}"
 
 # Avoiding the following error: 
 # msg="cleanup working directory in namespace" 
 # error="open <dir>/containerd/daemon/io.containerd.runtime.v2.task/moby: no such file or directory"
 # namespace=moby
-mkdir -p "$data_dir"/containerd/daemon/io.containerd.runtime.v2.task/moby
+mkdir -p "$data_root"/containerd/daemon/io.containerd.runtime.v2.task/moby
 
 exec dockerd \
 	--group "$default_socket_group" \
 	--exec-root="$run_dir" \
-  	--data-root="$data_dir" \
+  	--data-root="$data_root" \
 	--pidfile="$run_dir/docker.pid" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	"$@"

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -66,12 +66,6 @@ workaround_apparmor_profile_reload
 data_root="$(snapctl get data-root)"
 data_root="${data_root:-$DEFAULT_DATA_ROOT}"
 
-# Avoiding the following error: 
-# msg="cleanup working directory in namespace" 
-# error="open <dir>/containerd/daemon/io.containerd.runtime.v2.task/moby: no such file or directory"
-# namespace=moby
-mkdir -p "$data_root"/containerd/daemon/io.containerd.runtime.v2.task/moby
-
 exec dockerd \
 	--group "$default_socket_group" \
 	--exec-root="$run_dir" \

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -63,10 +63,13 @@ workaround_lp1606510
 
 workaround_apparmor_profile_reload
 
+DATA_DIR="$(snapctl get data-dir)"
+data_dir="${DATA_DIR:-$DEFAULT_DATA_DIR}"
+
 exec dockerd \
 	--group "$default_socket_group" \
 	--exec-root="$run_dir" \
-	--data-root="$SNAP_COMMON/var-lib-docker" \
+  	--data-root="$data_dir" \
 	--pidfile="$run_dir/docker.pid" \
 	--config-file="$SNAP_DATA/config/daemon.json" \
 	"$@"

--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -65,6 +65,8 @@ workaround_apparmor_profile_reload
 
 data_root="$(snapctl get data-root)"
 data_root="${data_root:-$DEFAULT_DATA_ROOT}"
+# Feedback for the user in case the data-root is set to the default
+snapctl set data-root="$data_root"
 
 exec dockerd \
 	--group "$default_socket_group" \

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -7,6 +7,13 @@ exec &> >(tee -a "${HOOK_LOG}")
 
 . "${SNAP}/usr/share/nvidia-container-toolkit/lib"
 
+# Change the data-root
+data_root="$(snapctl get data-root)"
+if [ -z "$data_root" ] ; then
+    # If the user unset the data-root, set it to the default
+    snapctl set data-root="${DEFAULT_DATA_ROOT}"
+fi
+
 # Flag to trigger service restart if any condition requires it #
 SVC_RESTART=false
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -7,10 +7,9 @@ exec &> >(tee -a "${HOOK_LOG}")
 
 . "${SNAP}/usr/share/nvidia-container-toolkit/lib"
 
-# Change the data-root
+# If the user unset the data-root, set it to the default
 data_root="$(snapctl get data-root)"
 if [ -z "$data_root" ] ; then
-    # If the user unset the data-root, set it to the default
     snapctl set data-root="${DEFAULT_DATA_ROOT}"
 fi
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,6 +4,13 @@ set -eu
 
 . "${SNAP}/usr/share/nvidia-container-toolkit/lib"
 
+# Since the install hook is also the post-refresh hook, 
+# we need to check if the data-root is set
+data_root="$(snapctl get data-root)"
+if [ -z "$data_root" ] ; then
+    snapctl set data-root="${DEFAULT_DATA_ROOT}"
+fi
+
 # ensure the layouts dir for /etc/{stuff} exists
 mkdir -p "$SNAP_DATA/etc/docker"
 mkdir -p "$SNAP_DATA/config"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,8 +4,8 @@ set -eu
 
 . "${SNAP}/usr/share/nvidia-container-toolkit/lib"
 
-# Since the install hook is also the post-refresh hook, 
-# we need to check if the data-root is set
+# Since the install hook is also the post-refresh hook, we need to check if the data-root is set
+# and set it to default if it's not set
 data_root="$(snapctl get data-root)"
 if [ -z "$data_root" ] ; then
     snapctl set data-root="${DEFAULT_DATA_ROOT}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ layout:
     symlink: $SNAP/usr/libexec/docker/cli-plugins
 
 environment:
-  DEFAULT_DATA_DIR: "$SNAP_COMMON/var-lib-docker"
+  DEFAULT_DATA_ROOT: "$SNAP_COMMON/var-lib-docker"
   GIT_EXEC_PATH: "$SNAP/usr/lib/git-core"
   GIT_TEMPLATE_DIR: "$SNAP/usr/share/git-core/templates"
   # For nvidia support #

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,7 @@ layout:
     symlink: $SNAP/usr/libexec/docker/cli-plugins
 
 environment:
+  DEFAULT_DATA_DIR: "$SNAP_COMMON/var-lib-docker"
   GIT_EXEC_PATH: "$SNAP/usr/lib/git-core"
   GIT_TEMPLATE_DIR: "$SNAP/usr/share/git-core/templates"
   # For nvidia support #

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,6 @@ environment:
 plugs:
   home:
     read: all
-  removable-media:
   support:
     interface: docker-support
   privileged:
@@ -81,6 +80,7 @@ apps:
     command: bin/dockerd-wrapper
     daemon: simple
     plugs:
+      - removable-media
       - firewall-control
       - home
       - log-observe
@@ -95,6 +95,7 @@ apps:
   compose:
     command: usr/libexec/docker/cli-plugins/docker-compose
     plugs:
+      - removable-media
       - docker-cli
       - network
       - home


### PR DESCRIPTION
This PR provides the changes:

- Introduces the `data-dir` [snap option](https://snapcraft.io/docs/configuration-in-snaps). 
- Defaults `data-dir` to the current value `$SNAP_COMMON/var-lib-docker`
- Add documentation on README.md with usage instructions 
- Closes: https://github.com/canonical/docker-snap/issues/64
- Fixes: https://github.com/canonical/docker-snap/issues/3

Important considerations:
-  The directory chosen to hold the engine data gets owned by the `root` user. 
- If the directory doesn't exist, but it's pointed to a location where the snap was writing access, it gets created, a side effect of https://github.com/canonical/docker-snap/pull/235/commits/3030a23ae1ba5e63393b1cd4249aca5a3964d6ce
- If the directory is pointed to some place where the docker snap isn't allowed to write, if fails with the error:
  `mkdir: cannot create directory ‘<dir>’: Read-only file system`
- The functionality of being able to use directories from a removable media driver isn't working due [to this problem](https://github.com/canonical/docker-snap/pull/235#issuecomment-2665858460).
 

## Testing

For testing, build the snap and connect all needed interfaces, then:
```console
ubuntu@datdir:~$ sudo snap get docker
error: snap "docker" has no configuration
ubuntu@datdir:~$
ubuntu@datdir:~$ cd
ubuntu@datdir:~$ mkdir docker-data
ubuntu@datdir:~$ sudo snap set docker data-dir=$HOME/docker-data
ubuntu@datdir:~$ sudo snap get docker
Key       Value
data-dir  /home/ubuntu/docker-data
ubuntu@datdir:~$
ubuntu@datdir:~$ sudo systemctl status snap.docker.dockerd.service
● snap.docker.dockerd.service - Service for snap application docker.dockerd
     Loaded: loaded (/etc/systemd/system/snap.docker.dockerd.service; enabled; preset: enabled)
     Active: active (running) since Tue 2025-02-18 13:35:14 UTC; 14s ago
   Main PID: 18672 (dockerd)
      Tasks: 16 (limit: 1095)
     Memory: 101.9M (peak: 101.9M)
        CPU: 1.047s
     CGroup: /system.slice/snap.docker.dockerd.service
             ├─18672 dockerd --group docker --exec-root=/run/snap.docker --data-root=/home/ubuntu/docker-data --pidfile=/run/snap.docker/docker.pid --config-file=/var/snap/docker/x1/config/daemon.json
             └─18729 containerd --config /run/snap.docker/containerd/containerd.toml --log-level error

Feb 18 13:35:14 datdir systemd[1]: Started snap.docker.dockerd.service - Service for snap application docker.dockerd.

```
