### PR TITLE
(DO NOT MERGE) test: try dropping workaround for modprobe from a63b45c6068a686

### DIFF
--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -22,27 +22,6 @@ workaround_lp1606510() {
 	fi
 }
 
-yolo() {
-	"$@" > /dev/null 2>&1 || :
-}
-
-force_umount() {
-	yolo umount    "$@"
-	yolo umount -f "$@"
-	yolo umount -l "$@"
-}
-
-dir="$(mktemp -d)"
-trap "force_umount --no-mtab '$dir'; rm -rf '$dir'" EXIT
-# try mounting a few FS types to force the kernel to try loading modules
-for t in aufs overlay zfs; do
-	yolo mount --no-mtab -t "$t" /dev/null "$dir"
-	force_umount --no-mtab "$dir"
-done
-# inside our snap, we can't "modprobe" for whatever reason (probably no access to the .ko files)
-# so this forces the kernel itself to "modprobe" for these filesystems so that the modules we need are available to Docker
-rm -rf "$dir"
-trap - EXIT
 
 # modify XDG_RUNTIME_DIR to be a snap writable dir underneath $SNAP_COMMON 
 # (until https://bugs.launchpad.net/snappy/+bug/1656340 is fixed)


### PR DESCRIPTION
:warning:  DO NOT MERGE :warning: 