### PR TITLE
doc: docker aliases 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo snap connect docker:home
 ```
 
 The `docker-compose` [alias](https://snapcraft.io/docs/commands-and-aliases) was set automatically for Compose V1 and remains for backwards-compatiblity.
-The recommended command-line syntax since Compose V2 is `docker compose` as described on the [Docker's official documentation](https://docs.docker.com/compose/releases/migrate/).
+The recommended command-line syntax since Compose V2 is `docker compose` as described [here](https://docs.docker.com/compose/releases/migrate/).
 
 ### Changing the data root directory
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ If you are using Ubuntu Core 16, connect the `docker:home` plug as it's not auto
 sudo snap connect docker:home
 ```
 
+The `docker-compose` [alias](https://snapcraft.io/docs/commands-and-aliases) was set automatically for Compose V1 and remains for backwards-compatiblity.
+The recommended command-line syntax since Compose V2 is `docker compose` as described on the [Docker's official documentation](https://docs.docker.com/compose/releases/migrate/).
+
 ### Changing the data root directory
 
 In the `docker` snap, the default location for the [data-root](https://docs.docker.com/engine/daemon/#daemon-data-directory) directory is `$SNAP_COMMON/var-lib-docker`, which maps to `/var/snap/docker/common/var-lib-docker` based on the [snap data locations](https://snapcraft.io/docs/data-locations#heading--system).
@@ -60,21 +63,6 @@ Then restart the dockerd service:
 ```shell
 sudo snap restart docker.dockerd
 ```
-
-### Docker Snap Aliases
-
-[Snap aliases](https://snapcraft.io/docs/commands-and-aliases) are part of the Snap ecosystem.  
-When installing Docker from the [Snap Store](https://snapcraft.io/), the alias `docker-compose` is automatically created, pointing to `docker.compose`.  
-
-You can verify this by running:  
-
-```console
-$ snap aliases docker
-Command         Alias           Notes
-docker.compose  docker-compose  -
-```  
-
-Although the [migration to Compose V2](https://docs.docker.com/compose/releases/migrate/) deprecates the `docker-compose` command in favor of `docker compose`, the alias still exists for backward compatibility.
 
 ### Running Docker as normal user
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,18 @@ sudo snap restart docker.dockerd
 
 ### Docker Snap Aliases
 
-[Snap aliases](https://snapcraft.io/docs/commands-and-aliases) are part of snap ecosystem.
-When installing Docker from the [store](https://snapcraft.io/) the alias `docker-compose` gets automatically set pointing to `docker.compose`.
+[Snap aliases](https://snapcraft.io/docs/commands-and-aliases) are part of the Snap ecosystem.  
+When installing Docker from the [Snap Store](https://snapcraft.io/), the alias `docker-compose` is automatically created, pointing to `docker.compose`.  
 
-That can be checked running:
+You can verify this by running:  
 
 ```console
 $ snap aliases docker
 Command         Alias           Notes
 docker.compose  docker-compose  -
-```
+```  
 
+Although the [migration to Compose V2](https://docs.docker.com/compose/releases/migrate/) deprecates the `docker-compose` command in favor of `docker compose`, the alias still exists for backward compatibility.
 
 ### Running Docker as normal user
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ Then restart the dockerd service:
 sudo snap restart docker.dockerd
 ```
 
+### Docker Snap Aliases
+
+[Snap aliases](https://snapcraft.io/docs/commands-and-aliases) are part of snap ecosystem.
+When installing Docker from the [store](https://snapcraft.io/) the alias `docker-compose` gets automatically set pointing to `docker.compose`.
+
+That can be checked running:
+
+```console
+$ snap aliases docker
+Command         Alias           Notes
+docker.compose  docker-compose  -
+```
+
+
 ### Running Docker as normal user
 
 By default, Docker is only accessible with root privileges (`sudo`). If you want to use docker as a regular user, you need to add your user to the `docker` group. This isn't possible on Ubuntu Core because it disallows the addition of users to system groups [[1](https://forum.snapcraft.io/t/adding-users-to-system-groups-on-ubuntu-core/20109), [2](https://github.com/snapcore/core20/issues/72)].


### PR DESCRIPTION
Add Documentation regarding the existence of Docker alias `docker-compose` poiting to the `compose` app.

[skip ci]