### PR TITLE
doc: Add missing supported `riscv64` and `s390x` architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Docker Snap
 
-This repository contains the source for the `docker` snap package.  The package provides a distribution of Docker Engine along with the Nvidia toolkit for Ubuntu Core and other snap-compatible systems.  The Docker Engine is built from an upstream release tag with some patches to fit the snap format and is available on `armhf`, `arm64`, `amd64`, `i386`, and `ppc64el` architectures.  The rest of this page describes installation, usage, and development.
+This repository contains the source for the `docker` snap package.  The package provides a distribution of Docker Engine along with the Nvidia toolkit for Ubuntu Core and other snap-compatible systems.  The Docker Engine is built from an upstream release tag with some patches to fit the snap format and is available on `armhf`, `arm64`, `amd64`, `i386`, `ppc64el`, `riscv64` and `s390x` architectures.  The rest of this page describes installation, usage, and development.
 
 > [!NOTE]
 > [Docker's official documentation](https://docs.docker.com) does not discuss the `docker` snap package. For questions regarding the snap usage, refer to the [discussions](https://github.com/canonical/docker-snap/discussions).


### PR DESCRIPTION
Matches on the list what is seeing when listing the available architectures for Docker snap [on the store](https://snapcraft.io/docker):

![image](https://github.com/user-attachments/assets/0eb21577-a93e-48c4-8129-2c9c00c49e40)

