### PR TITLE
chore(upgrade.sh): Add function preventing yq from deleting blank lines

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -2,6 +2,11 @@
 
 set -eux
 
+# yq preserving blank lines
+yq_pb() {
+  yq "$1" "$2" | diff -wB "$2" - | patch "$2" -
+}
+
 fetch_latest() {
   # Fetch latest version from Github releases API
   LATEST=$(curl -s "https://api.github.com/repos/moby/moby/releases?per_page=1" | jq -r '.[0].tag_name')
@@ -89,7 +94,7 @@ main() {
   done
 
   # Replace the `version:` field with the value of $SNAP_VERSION
-  yq -i ".version = \"$SNAP_VERSION\"" "$yaml_file"
+  yq_pb ".version = \"$SNAP_VERSION\"" "$yaml_file"
 
   # Replace fields in YAML using a loop
   declare -A yaml_updates=(
@@ -103,11 +108,11 @@ main() {
   )
 
   for part in "${!yaml_updates[@]}"; do
-    yq -i ".parts.${part} = \"${yaml_updates[$part]}\"" "$yaml_file"
+    yq_pb ".parts.${part} = \"${yaml_updates[$part]}\"" "$yaml_file"
   done
 
   # Replace `build-snaps` for `engine` with $GO_VERSION
-  yq -i '.parts.engine."build-snaps"[0] |= sub("[0-9]+\.[0-9]+", "'"$GO_VERSION"'")' "$yaml_file"
+  yq_pb '.parts.engine."build-snaps"[0] |= sub("[0-9]+\.[0-9]+", "'"$GO_VERSION"'")' "$yaml_file"
 
   # Replace the remaining comments
   sed -i "s/moby\/blob\/$CURRENT/moby\/blob\/$LATEST/g" "$yaml_file"


### PR DESCRIPTION
`yq` generates unnecessary diff by discarding blank lines during yaml unmarshalling, a side effect of [gopkg.in/yaml.v3](https://pkg.go.dev/gopkg.in/yaml.v3) library.

This adds the function `yq_pb` that:

1. Takes the `yq` expression and the target file as argument and passes to yq;
2. Generates a diff of the yaml file compared to the yq change ignoring the blank lines and blank spaces (`-B` and `-w`);
3. Apply the patch back to the original yaml file.


# Testing:

For testing follow the steps:
```shell
# Fetch the changes from this PR:
git clone git@github.com:canonical/docker-snap.git && cd docker-snap
git fetch origin pull/255/head:fix-yq-on-upgrade
git checkout fix-yq-on-upgrade


# revert and stash the changes of last commit:
git reset --soft HEAD^
git stash

# Go to the commit: d28b3d427 (or any older commit)
git checkout d28b3d427
git stash pop

# Run the script:
./upgrade.sh

# Check the clean diff:
git diff snap/snapcraft.yaml
```