### PR TITLE
ci(smoke-test): Regression test to check non-stopping container problem

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -182,7 +182,7 @@ jobs:
       # NOTE: regression test for aa default profile reload issue 
       # see: https://github.com/canonical/docker-snap/issues/36
       - name: Stop container
-        timeout-minutes: 3
+        timeout-minutes: 1
         run: |
           trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
           docker run --rm -d --name test bash bash -c 'cleanup(){ sleep 60; }; trap cleanup SIGTERM SIGINT SIGHUP SIGQUIT; while true; do sleep 1; done'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -184,8 +184,8 @@ jobs:
       - name: Stop container
         run: |
           trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
-          sudo docker run --rm --name test -e POSTGRES_PASSWORD=pass -d postgres
-          sleep 30
+          docker run --rm -d --name test bash bash -c 'cleanup(){ sleep 60; }; trap cleanup SIGTERM SIGINT SIGHUP SIGQUIT; while true; do sleep 1; done'
+          sleep 5
           sudo docker stop test
 
       - name: Docker Build

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -179,6 +179,15 @@ jobs:
       - name: Hello World (init)
         run: sudo docker run --rm --init hello-world
 
+      # NOTE: regression test for aa default profile reload issue 
+      # see: https://github.com/canonical/docker-snap/issues/36
+      - name: Stop container
+        run: |
+          trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
+          sudo docker run --rm --name test -e POSTGRES_PASSWORD=pass -d postgres
+          sleep 30
+          sudo docker stop test
+
       - name: Docker Build
         run: |
           sudo docker build --pull -t debian-hello - <<'EOF'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -182,6 +182,7 @@ jobs:
       # NOTE: regression test for aa default profile reload issue 
       # see: https://github.com/canonical/docker-snap/issues/36
       - name: Stop container
+        timeout-minutes: 3
         run: |
           trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
           docker run --rm -d --name test bash bash -c 'cleanup(){ sleep 60; }; trap cleanup SIGTERM SIGINT SIGHUP SIGQUIT; while true; do sleep 1; done'


### PR DESCRIPTION
There is no smoke-test for testing the ability to **stop containers**, and **check** if:

- https://github.com/canonical/docker-snap/blob/4418a554b08359e4b38835049f578048ae517e0a/bin/dockerd-wrapper#L4-L14
- https://github.com/canonical/docker-snap/blob/4418a554b08359e4b38835049f578048ae517e0a/patches/engine/0001-snappy-aa-profile-reload.patch#L27

Still being effective.