### PR TITLE
Upgrade to 28.0.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: docker
-version: '28.0.1'
+version: '28.0.2'
 summary: Docker container runtime
 description: Refer to https://snapcraft.io/docker
 license: (Apache-2.0 AND MIT AND GPL-2.0)
@@ -141,7 +141,7 @@ parts:
   engine:
     plugin: make
     source: https://github.com/moby/moby.git
-    source-tag: v28.0.1
+    source-tag: v28.0.2
     source-depth: 1
     override-build: |
       $CRAFT_STAGE/patches/patch.sh
@@ -164,7 +164,7 @@ parts:
       install -T bundles/dynbinary-daemon/dockerd "$CRAFT_PART_INSTALL/bin/dockerd"
       # install docker-proxy previously provided by libnetwork part
       install -T bundles/dynbinary-daemon/docker-proxy "$CRAFT_PART_INSTALL/bin/docker-proxy"
-    # https://github.com/moby/moby/blob/v28.0.1/Dockerfile#L3 (Docker-supported Go version for Engine)
+    # https://github.com/moby/moby/blob/v28.0.2/Dockerfile#L3 (Docker-supported Go version for Engine)
     build-snaps: &go ['go/1.23/stable']
     # we get weird behavior if we mix/match Go versions throughout this one snapcraft.yml, so we use a YAML reference here to ensure we're always consistent throughout
     after: [wrapper-scripts]
@@ -188,8 +188,8 @@ parts:
   containerd:
     plugin: make
     source: https://github.com/containerd/containerd.git
-    # from https://github.com/moby/moby/blob/v28.0.1/Dockerfile#L199
-    source-tag: v1.7.25
+    # from https://github.com/moby/moby/blob/v28.0.2/Dockerfile#L199
+    source-tag: v1.7.27
     source-depth: 1
     override-build: |
       make GIT_COMMIT= GIT_BRANCH= LDFLAGS=
@@ -205,7 +205,7 @@ parts:
   runc:
     plugin: make
     source: https://github.com/opencontainers/runc.git
-    # from https://github.com/moby/moby/blob/v28.0.1/Dockerfile#L290
+    # from https://github.com/moby/moby/blob/v28.0.2/Dockerfile#L290
     source-tag: v1.2.5
     source-depth: 1
     override-build: |
@@ -268,7 +268,7 @@ parts:
     plugin: cmake
     source: https://github.com/krallin/tini.git
     source-type: git
-    # from https://github.com/moby/moby/blob/v28.0.1/Dockerfile#L325
+    # from https://github.com/moby/moby/blob/v28.0.2/Dockerfile#L325
     source-tag: v0.19.0
     source-depth: 1
     organize:
@@ -282,7 +282,7 @@ parts:
     plugin: make
     build-snaps: *go
     source: https://github.com/docker/cli.git
-    source-tag: v28.0.0-rc.1
+    source-tag: v28.0.1
     source-depth: 1
     override-build: |
       # docker build specific environment variables
@@ -309,7 +309,7 @@ parts:
   buildx:
     plugin: nil
     source: https://github.com/docker/buildx.git
-    # https://github.com/moby/moby/blob/v28.0.1/Dockerfile#L15
+    # https://github.com/moby/moby/blob/v28.0.2/Dockerfile#L15
     source-tag: v0.20.1
     source-depth: 1
     override-build: |
@@ -324,8 +324,8 @@ parts:
     plugin: make
     source: https://github.com/docker/compose.git
     # https://github.com/docker/docker-ce-packaging/blob/master/common.mk // reference URL
-    # https://github.com/moby/moby/blob/v28.0.1/Dockerfile#L16 // Fetch from
-    source-tag: v2.33.1 # Ahead of Moby because of https://github.com/canonical/docker-snap/issues/251
+    # https://github.com/moby/moby/blob/v28.0.2/Dockerfile#L16 // Fetch from
+    source-tag: v2.33.1
     source-depth: 1
     override-build: |
       make build


### PR DESCRIPTION
- compose-v2 now in sync with Moby: 
  - https://github.com/moby/moby/blob/v28.0.2/Dockerfile#L19