### PR TITLE
chore: require additional information on issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -44,14 +44,18 @@ body:
 
             echo -e "\nSnapd information:"
             snap version
+
+            echo -e "\nSnapd snap pkg information:"
             snap list snapd
-            apt list snapd
+
+            echo -e "\nSnapd deb pkg information:"
+            apt list snapd 2>/dev/null | grep snapd
 
             echo -e "\nAppArmor ABI version:"
             apparmor_parser --version
 
             echo -e "\nAppArmor deb pkg version:"
-            apt list apparmor
+            apt list apparmor 2>/dev/null | grep apparmor
 
             echo -e "\nOS release:"
             cat /etc/os-release

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -36,26 +36,14 @@ body:
         Kindly copy **all** the commands below, run them in your terminal,
         and share the results here.
           ```bash
-            echo -e "\nDocker snap information:"
-            snap list docker
+            echo -e "\nSnap information:"
+            snap list docker snapd
 
             echo -e "\nPlug Connections:"
             snap connections docker
 
-            echo -e "\nSnapd information:"
-            snap version
-
-            echo -e "\nSnapd snap pkg information:"
-            snap list snapd
-
-            echo -e "\nSnapd deb pkg information:"
-            apt list snapd 2>/dev/null | grep snapd
-
-            echo -e "\nAppArmor ABI version:"
+            echo -e "\nAppArmor version:"
             apparmor_parser --version
-
-            echo -e "\nAppArmor deb pkg version:"
-            apt list apparmor 2>/dev/null | grep apparmor
 
             echo -e "\nOS release:"
             cat /etc/os-release

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -44,6 +44,14 @@ body:
 
             echo -e "\nSnapd information:"
             snap version
+            snap list snapd
+            apt list snapd
+
+            echo -e "\nAppArmor ABI version:"
+            apparmor_parser --version
+
+            echo -e "\nAppArmor deb pkg version:"
+            apt list apparmor
 
             echo -e "\nOS release:"
             cat /etc/os-release


### PR DESCRIPTION
Additional required info:

- `snap list snapd`: Get the **revision number** of `snapd`
- `apt list snapd`: Get the **deb package version** of `snapd`
- `apparmor_parser --version`: Check the ABI version of AppArmor.
-  `apt list apparmor`: Check the deb package version of AppArmor
    - This information, together with the previous one, help to **identify** if the user is running a **custom version** of AppArmor userspace tools.
    - Also, make it easier to reproduce the userspace AppArmor environment.