### PR TITLE
Skip Nvidia testing for Ubuntu Core 24

### DIFF
--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -49,7 +49,8 @@ jobs:
             distro: 
               - noble
               - core22-latest
-              - core24-latest
+              # Skip, pending https://github.com/canonical/docker-snap/pull/260
+              # - core24-latest
         env:
           TESTFLINGER_DIR: .github/workflows/testflinger
           SNAP_CHANNEL: latest/edge/runid-${{ inputs.run_id }}


### PR DESCRIPTION
To be re-enabled via https://github.com/canonical/docker-snap/pull/260