### PR TITLE
ci: drop Focal (ubuntu-20.04) from os test matrix

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,8 +53,6 @@ jobs:
             os: ubuntu-24.04
           - arch: amd64
             os: ubuntu-22.04
-          - arch: amd64
-            os: ubuntu-20.04
           - arch: arm64
             os: ubuntu-24.04-arm
           - arch: arm64


### PR DESCRIPTION
- Ubuntu 20.04 LTS runner got removed on 2025-04-15
- see: https://github.com/actions/runner-images/issues/11101