### PR TITLE
Change container path for nvidia binaries to make them discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,16 +169,11 @@ or
 docker run --rm --runtime nvidia --env NVIDIA_VISIBLE_DEVICES=all {cuda-container-image-name}
 ```
 
-If your container image already has appropriate environment variables set, may be able to just specify the nvidia runtime with no additional args required.
+If your container image already has appropriate environment variables set, you may be able to just specify the nvidia runtime with no additional args required.
 
-Please refer to [this guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html) for mode detail regarding environment variables that can be used.
-
-*NOTE*: library path and discovery is automatically handled, but binary paths are not, so if you wish to test using something like the `nvidia-smi` binary passed into the container from the host, you could either specify the full path or set the PATH environment variable.
-
-e.g.
-
+You may run `nvidia-smi` to validate the environment set up from a temporary container:
 ```
-docker run --rm --runtime=nvidia --gpus all --env PATH="${PATH}:/var/lib/snapd/hostfs/usr/bin" ubuntu nvidia-smi
+docker run --rm --runtime=nvidia --gpus all ubuntu nvidia-smi
 ```
 
 ## Development

--- a/nvidia/lib
+++ b/nvidia/lib
@@ -66,7 +66,18 @@ cdi_generate () {
     [ "${NVIDIA_SUPPORT_CLASSIC}" == "true" ] && CDI_CONFIG_SEARCH_PATH="/var/lib/snapd/hostfs/usr/share"
     [ "${NVIDIA_SUPPORT_CLASSIC}" == "true" ] && CDI_PATH="${PATH}:/var/lib/snapd/hostfs/usr/bin"
 
-    XDG_DATA_DIRS="${XDG_DATA_DIRS:-}:${CDI_CONFIG_SEARCH_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CDI_LIB_SEARCH_PATH}" PATH="${CDI_PATH}" "${SNAP}/usr/bin/nvidia-ctk" cdi generate --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" --library-search-path "${CDI_LIB_SEARCH_PATH}" --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    # Generate the CDI spec
+    XDG_DATA_DIRS="${XDG_DATA_DIRS:-}:${CDI_CONFIG_SEARCH_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CDI_LIB_SEARCH_PATH}" PATH="${CDI_PATH}" \
+     "${SNAP}/usr/bin/nvidia-ctk" cdi generate \
+     --nvidia-ctk-path "${SNAP}/usr/bin/nvidia-ctk" \
+     --library-search-path "${CDI_LIB_SEARCH_PATH}" \
+     --device-name-strategy "${CDI_DEVICE_NAME_STRATEGY}" \
+     --output "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+
+    if [ "${NVIDIA_SUPPORT_CLASSIC}" == "true" ] ; then
+        # Replace container path for binaries such as nvidia-smi to make them discoverable from the default PATH
+        sed -i "s|containerPath: /var/lib/snapd/hostfs/usr/bin|containerPath: /usr/bin|g" "${SNAP_DATA}/etc/cdi/nvidia.yaml"
+    fi
 }
 
 # Create the nvidia runtime config, either snap default or custom #


### PR DESCRIPTION
Fixes #184 

The generated CDI spec sets container base paths to ` /var/lib/snapd/hostfs/usr/bin`:
```console
$ cat /var/snap/docker/current/etc/cdi/nvidia.yaml
containerEdits:
  <...>
  env:
  - NVIDIA_VISIBLE_DEVICES=void
  <...>
  mounts:
  <...>
  - containerPath: /var/lib/snapd/hostfs/usr/bin/nvidia-smi
    hostPath: /var/lib/snapd/hostfs/usr/bin/nvidia-smi
    options:
    - ro
    - nosuid
    - nodev
    - bind
```

This path is not included in the default search PATH:
```console
$ sudo docker run --rm --runtime=nvidia --gpus all ubuntu env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=1571d8996069
NVIDIA_VISIBLE_DEVICES=void
HOME=/root
```

As a result, the following binaries are not discoverable from the default search paths.
One can execute them with absolute path or after adding the hostfs directory to PATH (as documented in README).

```console
$ sudo docker run --rm --runtime=nvidia --gpus all ubuntu ls /var/lib/snapd/hostfs/usr/bin
nvidia-cuda-mps-control
nvidia-cuda-mps-server
nvidia-debugdump
nvidia-persistenced
nvidia-smi
```

This PR changes the runtime logic so that the container path is `/usr/bin` instead of `/var/lib/snapd/hostfs/usr/bin`; similar to where nvidia binaries are available on the host. 

There may be a better way to solve this by making the runtime append to the PATH, but I could not find a way of doing so.