### PR TITLE
refact: simplify graphics provider checks

### DIFF
--- a/nvidia/lib
+++ b/nvidia/lib
@@ -12,9 +12,7 @@ NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 NVIDIA_SUPPORT_CLASSIC="false"
 [ -L "/var/lib/snapd/hostfs/usr/lib/${ARCH_TRIPLET}/libcuda.so" ] && NVIDIA_SUPPORT_CLASSIC="true"
 
-if snapctl is-connected gpu-2404; then
-    NVIDIA_SUPPORT_CORE="true"
-elif snapctl is-connected graphics-core22; then
+if snapctl is-connected gpu-2404 || snapctl is-connected graphics-core22; then
     NVIDIA_SUPPORT_CORE="true"
 else
     NVIDIA_SUPPORT_CORE="false"

--- a/nvidia/lib
+++ b/nvidia/lib
@@ -12,9 +12,13 @@ NVIDIA_SUPPORT_DISABLED="$(snapctl get nvidia-support.disabled)"
 NVIDIA_SUPPORT_CLASSIC="false"
 [ -L "/var/lib/snapd/hostfs/usr/lib/${ARCH_TRIPLET}/libcuda.so" ] && NVIDIA_SUPPORT_CLASSIC="true"
 
-NVIDIA_SUPPORT_CORE="false"
-snapctl is-connected gpu-2404 && NVIDIA_SUPPORT_CORE="true"
-snapctl is-connected graphics-core22 && NVIDIA_SUPPORT_CORE="true"
+if snapctl is-connected gpu-2404; then
+    NVIDIA_SUPPORT_CORE="true"
+elif snapctl is-connected graphics-core22; then
+    NVIDIA_SUPPORT_CORE="true"
+else
+    NVIDIA_SUPPORT_CORE="false"
+fi
 
 
 device_wait() {


### PR DESCRIPTION
- The condition should be an if-else case (or an `|| exit 0` at the end of the statements)