### PR TITLE
build: upgrade nvidia parts to v1.17.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -231,7 +231,7 @@ parts:
   nvidia-container-toolkit:
     plugin: go
     source: https://github.com/NVIDIA/nvidia-container-toolkit.git
-    source-tag: v1.17.3
+    source-tag: v1.17.8
     source-depth: 1
     override-pull: &arch-restrict |
       [ "${CRAFT_ARCH_BUILD_FOR}" != "amd64" ] && \
@@ -255,7 +255,7 @@ parts:
   libnvidia-container:
     plugin: make
     source: https://github.com/NVIDIA/libnvidia-container.git
-    source-tag: v1.17.3
+    source-tag: v1.17.8
     source-depth: 1
     override-pull: *arch-restrict
     override-build: *arch-restrict


### PR DESCRIPTION
Changelog extracted from the changes:

---
## v1.17.8

- Updated the ordering of Mounts in CDI to have a deterministic output. This makes testing more consistent.
- Added NVIDIA_CTK_DEBUG envvar to hooks.

### Changes in libnvidia-container

- Fixed bug in setting default for `--cuda-compat-mode` flag. This caused failures in use cases invoking the `nvidia-container-cli` directly.
- Added additional logging to the `nvidia-container-cli`.
- Fixed variable initialisation when updating the ldcache. This caused failures on Arch linux or other platforms where the `nvidia-container-cli` was built from source.

## v1.17.7

- Fix mode detection on Thor-based systems. This correctly resolves `auto` mode to `csv`.
- Fix resolution of libs in LDCache on ARM. This fixes CDI spec generation on ARM-based systems using NVML.
- Run update-ldcache hook in isolated namespaces.

### Changes in the Toolkit Container

- Bump CUDA base image version to 12.9.0

### Changes in libnvidia-container

- Add `--cuda-compat-mode` flag to the `nvidia-container-cli configure` command.

## v1.17.6

### Changes in the Toolkit Container

- Allow container runtime executable path to be specified when configuring containerd.
- Bump CUDA base image version to 12.8.1

### Changes in libnvidia-container

- Skip files when user has insufficient permissions. This prevents errors when discovering IPC sockets when the `nvidia-container-cli` is run as a non-root user.
- Fix building with Go 1.24
- Fix some typos in text.

## v1.17.5

- Allow the `enabled-cuda-compat` hook to be skipped when generating CDI specifications. This improves compatibility with older NVIDIA Container Toolkit installations. The hook is explicitly ignored for management CDI specifications.
- Add IMEX binaries to CDI discovery. This includes the IMEX Daemon and IMEX Control binaries in containers.
- Fix bug that may overwrite docker feature flags when configuring CDI from the `nvidia-ctk runtime configure` command.
- Remove the unused `Set()` function from engine config API.
- Add an `EnableCDI()` method to engine config API.
- Add an `ignore-imex-channel-requests` feature flag. This ensures that the NVIDIA Container Runtime can be configured to ignore IMEX channel requests when these should be managed by another component.
- Update the `update-ldcache` hook to run the host `ldconfig` from a MEMFD.
- Add support for CUDA Forward Compatibility (removed by default in v1.17.4) using a dedicated `enable-cuda-compat` hook.  This can be disabled using a `disable-cuda-compat-lib-hook` feature flag.
- Disable nvsandboxutils in the `nvcdi` API. This prevents a segmentation violation with NVIDIA GPU Drivers from the 565 branch.
- Fix a bug where `cdi` mode would not work with the `--gpus` flag even if the NVIDIA Container Runtime was used.

### Changes in the Toolkit Container

- Enable CDI in container engine (Containerd, Cri-o, Docker) if CDI_ENABLED is set.
- Bump CUDA base image version to 12.8.0

## v1.17.4
- Disable mounting of compat libs from container by default
- Add allow-cuda-compat-libs-from-container feature flag
- Skip graphics modifier in CSV mode
- Properly pass configSearchPaths to a Driver constructor
- Add support for containerd version 3 config
- Add string TOML source

### Changes in libnvidia-container
- Add no-cntlibs CLI option to nvidia-container-cli

### Changes in the Toolkit Container
- Bump CUDA base image version to 12.6.3

---
source: https://github.com/NVIDIA/nvidia-container-toolkit/compare/v1.17.3...v1.17.8

