### PR TITLE
ci(smoke-test): Use Debian tag stable-slim for simple build tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Docker Build
         run: |
           sudo docker build --pull -t debian-hello - <<'EOF'
-            FROM debian:buster-slim
+            FROM debian:sid-slim
             RUN set -eux; \
                 apt-get update; \
                 apt-get install -y hello; \
@@ -256,7 +256,7 @@ jobs:
         run: |
           trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
           sudo DOCKER_BUILDKIT=1 docker build --pull -t debian-hello - <<'EOF'
-            FROM debian:buster-slim
+            FROM debian:sid-slim
             RUN set -eux; \
                 apt-get update; \
                 apt-get install -y hello; \

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Docker Build
         run: |
           sudo docker build --pull -t debian-hello - <<'EOF'
-            FROM debian:sid-slim
+            FROM debian:stable-slim
             RUN set -eux; \
                 apt-get update; \
                 apt-get install -y hello; \
@@ -256,7 +256,7 @@ jobs:
         run: |
           trap 'echo "error, sad day ($?)"; sleep 1; sudo snap logs -n=20 docker.dockerd; sleep 1; sudo tail -n20 /var/log/*.log; sudo dmesg | tail -n20; sudo journalctl --no-pager | grep DENIED | grep docker' ERR
           sudo DOCKER_BUILDKIT=1 docker build --pull -t debian-hello - <<'EOF'
-            FROM debian:sid-slim
+            FROM debian:stable-slim
             RUN set -eux; \
                 apt-get update; \
                 apt-get install -y hello; \


### PR DESCRIPTION
The mirror of Debian Buster is failing due to network connections issues.
This problem can be easily reproduced by doing: `docker run --rm -it debian:buster-slim apt-get update`:

```console
$ docker run --rm -it debian:buster-slim apt-get update
Ign:1 http://deb.debian.org/debian buster InRelease
Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
Ign:3 http://deb.debian.org/debian buster-updates InRelease
Err:4 http://deb.debian.org/debian buster Release
  404  Not Found [IP: 151.101.178.132 80]
Err:5 http://deb.debian.org/debian-security buster/updates Release
  404  Not Found [IP: 151.101.178.132 80]
Err:6 http://deb.debian.org/debian buster-updates Release
  404  Not Found [IP: 151.101.178.132 80]
Reading package lists... Done
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

Which doesn't happen with Bullseye or Sid.

```console
$ docker run --rm -it debian:bullseye-slim apt-get update
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [27.2 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.0 kB]
Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8066 kB]
Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [384 kB]
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
Fetched 8656 kB in 1s (7589 kB/s)
Reading package lists... Done
```

Also, Buster reached already it's EOL, see: https://wiki.debian.org/DebianReleases