### PR TITLE
doc: fix name of nvidia components for pc-kernel snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ The required NVIDIA kernel objects and user-space libraries are available as opt
 
 ```shell
 # Install kernel components
-sudo snap install pc-kernel+nvidia-550-ko
-sudo snap install pc-kernel+nvidia-550-user
+sudo snap install pc-kernel+nvidia-550-erd-ko
+sudo snap install pc-kernel+nvidia-550-erd-user
 
 # Install the content provider snap
 sudo snap install mesa-2404


### PR DESCRIPTION
The names on the instruction for Nvidia components for the pc-kernel snap are wrong:

```console

$ sudo snap install pc-kernel+nvidia-550-ko
error: cannot install "pc-kernel": cannot find component "nvidia-550-ko" in snap resources

$ sudo snap install pc-kernel+nvidia-550-user
error: cannot install "pc-kernel": cannot find component "nvidia-550-user" in snap resources

```