### PR TITLE
fix: clear executable stack flag on libzpool

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -188,12 +188,23 @@ parts:
       - libsystemd-dev
       - patch
       - pkg-config
+      - to armhf:
+        - execstack
     stage-packages:
       - git
       - libltdl7
       - pigz
       - xz-utils
       - zfsutils-linux
+    override-stage: |
+      craftctl default
+      # clear executable stack flag bit on libzpool (from zfsutils-linux) when building for armhf
+      # to satisfy store validation
+      #
+      # we do it in override-stage because libzpool comes from stage-packages and therefore only exists in $CRAFT_STAGE
+      if [ "${CRAFT_ARCH_BUILD_FOR}" = "armhf" ]; then
+        find "$CRAFT_STAGE" -name "libzpool.so.*" -exec execstack --clear-execstack {} \;
+      fi
 
   containerd:
     plugin: make


### PR DESCRIPTION
Clear the executable stack flag on libzpool.so.x.x.x with 'execstack --clear-execstack'

When building the Docker snap for the armhf architecture, the Snap Store validation fails with the following error

> Found files with executable stack. This adds PROT_EXEC to mmap(2) during mediation which may cause security denials. Either adjust your program to not require an executable stack, strip it with 'execstack --clear-execstack ...' or remove the affected file from your snap. Affected files: lib/arm-linux-gnueabihf/libzpool.so.5.0.0 functional-snap-v2_execstack [What does this mean?](https://forum.snapcraft.io/t/snap-and-executable-stacks/1812)