### PR TITLE
Upgrade Docker compose to match Docker Engine Community version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -347,7 +347,7 @@ parts:
     source: https://github.com/docker/compose.git
     # https://github.com/docker/docker-ce-packaging/blob/master/common.mk // reference URL
     # https://github.com/moby/moby/blob/v28.3.3/Dockerfile#L16 // Fetch from
-    source-tag: v2.36.2
+    source-tag: v2.39.1
     source-depth: 1
     override-build: |
       make build


### PR DESCRIPTION
The docker compose shipped on Docker Engine Community is `v2.39.1`.

- Related to: https://github.com/canonical/docker-snap/issues/312

```console
ubuntu@nn:~$ sudo docker version
Client: Docker Engine - Community
 Version:           28.3.3
 API version:       1.51
 Go version:        go1.24.5
 Git commit:        980b856
 Built:             Fri Jul 25 11:34:09 2025
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          28.3.3
  API version:      1.51 (minimum version 1.24)
  Go version:       go1.24.5
  Git commit:       bea959c
  Built:            Fri Jul 25 11:34:09 2025
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.27
  GitCommit:        05044ec0a9a75232cad458027ca83437aae3f4da
 runc:
  Version:          1.2.5
  GitCommit:        v1.2.5-0-g59923ef
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
ubuntu@nn:~$ sudo docker compose version
Docker Compose version v2.39.1
ubuntu@nn:~$ which docker
/usr/bin/docker
ubuntu@nn:~$ dpkg -S /usr/bin/docker
docker-ce-cli: /usr/bin/docker
```