### PR TITLE
test: Bump nvidia components to 570

### DIFF
--- a/.github/workflows/testflinger/scripts/setup.sh
+++ b/.github/workflows/testflinger/scripts/setup.sh
@@ -61,8 +61,8 @@ setup_core24() (
   snap components pc-kernel
 
   # Install kernel components. 
-  sudo snap install pc-kernel+nvidia-550-erd-ko
-  sudo snap install pc-kernel+nvidia-550-erd-user
+  sudo snap install pc-kernel+nvidia-570-erd-ko
+  sudo snap install pc-kernel+nvidia-570-erd-user
   
   sudo snap install mesa-2404
 )


### PR DESCRIPTION
The version 550 of the component has reached EOL.