### PR TITLE
bin & snap: Automatic detection between nftables and legacy xtables

### DIFF
--- a/bin/ip6tables
+++ b/bin/ip6tables
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# If kernel support is missing, automatically assume xtables
+USE_NFTABLES="$(nft list ruleset > /dev/null 2> /dev/null && echo true || echo false)"
+
+# Otherwise resolve the iptables symlink from the host and use
+# xtables if it is pointing to xtables-legacy-multi
+if [ "$USE_NFTABLES" == "true" ]; then
+    if readlink -f /var/lib/snapd/hostfs/sbin/ip6tables 2>/dev/null | grep -q xtables-legacy-multi; then
+        USE_NFTABLES=false
+    fi
+
+    # If it's not a symlink then it is pure a pure xtables implementation
+    if readlink -f /var/lib/snapd/hostfs/sbin/ip6tables 2>/dev/null | grep -q "^/var/lib/snapd/hostfs/sbin/ip6tables"; then
+        USE_NFTABLES=false
+    fi
+fi
+
+if [ "$USE_NFTABLES" == "true" ]; then
+    IMPL=ip6tables-nft
+else
+    IMPL=ip6tables-legacy
+fi
+
+exec "$SNAP/usr/sbin/$IMPL" "$@"

--- a/bin/iptables
+++ b/bin/iptables
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# If kernel support is missing (and nft fails), automatically assume xtables
+USE_NFTABLES="$(nft list ruleset > /dev/null 2> /dev/null && echo true || echo false)"
+
+# Otherwise resolve the iptables symlink from the host and use
+# xtables if it is pointing to xtables-legacy-multi
+if [ "$USE_NFTABLES" == "true" ]; then
+    if readlink -f /var/lib/snapd/hostfs/sbin/iptables 2>/dev/null | grep -q xtables-legacy-multi; then
+        USE_NFTABLES=false
+    fi
+
+    # If it's not a symlink then it is pure a pure xtables implementation
+    if readlink -f /var/lib/snapd/hostfs/sbin/iptables 2>/dev/null | grep -q "^/var/lib/snapd/hostfs/sbin/iptables"; then
+        USE_NFTABLES=false
+    fi
+fi
+
+if [ "$USE_NFTABLES" == "true" ]; then
+    IMPL=iptables-nft
+else
+    IMPL=iptables-legacy
+fi
+
+exec "$SNAP/usr/sbin/$IMPL" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -124,6 +124,9 @@ parts:
     source: .
     stage-packages:
       - mount
+      - iptables
+      - nftables
+      - libnftables1
     organize:
       nvidia/lib: usr/share/nvidia-container-toolkit/lib
       nvidia/nvidia-container-toolkit: bin/
@@ -132,6 +135,8 @@ parts:
       nvidia/gpu-2404-optional-wrapper: bin/
     stage:
       - bin/*
+      - usr/sbin/*
+      - usr/lib/*
       - config/daemon.json
       - patches/*
       - usr/share/nvidia-container-toolkit/*
@@ -139,8 +144,16 @@ parts:
       - -bin/go-build-helper.sh
       - -patches/*
       - bin/*
+      - usr/sbin/*
+      - usr/lib/*
       - config/daemon.json
       - usr/share/nvidia-container-toolkit/*
+    override-stage: |
+      craftctl default
+      ln -sf xtables-legacy-multi $CRAFT_STAGE/usr/sbin/iptables-legacy
+      ln -sf xtables-legacy-multi $CRAFT_STAGE/usr/sbin/ip6tables-legacy
+      ln -sf xtables-nft-multi $CRAFT_STAGE/usr/sbin/iptables-nft
+      ln -sf xtables-nft-multi $CRAFT_STAGE/usr/sbin/ip6tables-nft
 
   utils:
     plugin: nil


### PR DESCRIPTION
Introduces iptables wrappers to detect and select whether to use nftables
or legacy xtables for configuring the firewall. This is done by running
a simple 'nft list ruleset' command to see whether it succeeds or not.
If it does not, fall back to using iptables-legacy as symlinked in the
snap, instead of using the wrong symlink from core24.

Addresses: https://github.com/canonical/docker-snap/issues/138