### PR TITLE
Upgrade to v29.0.0

### DIFF
--- a/bin/go-build-helper.sh
+++ b/bin/go-build-helper.sh
@@ -24,7 +24,4 @@ gopartbootstrap()
 
 	# finally go into the go import path to prepare for building
 	cd "$GOIMPORTPATH"
-
-	# TODO hopefully temporary hack :(
-	export GO111MODULE=off
 }

--- a/patches/engine/0001-snappy-aa-profile-reload.patch
+++ b/patches/engine/0001-snappy-aa-profile-reload.patch
@@ -1,25 +1,25 @@
-From 407abbba714f69e316a11b10bc654353045f3309 Mon Sep 17 00:00:00 2001
+From 5621af0a01cfd03acdac7363d8580af8d6699670 Mon Sep 17 00:00:00 2001
 From: Lucas Kanashiro <lucas.kanashiro@canonical.com>
 Date: Wed, 23 Aug 2023 18:54:54 -0300
-Subject: [PATCH 1/5] snappy-aa-profile-reload
+Subject: [PATCH 1/6] snappy-aa-profile-reload
 
 ---
  daemon/apparmor_default.go | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/daemon/apparmor_default.go b/daemon/apparmor_default.go
-index 6376001613..d9be0dc683 100644
+index a1048e303c..55934032ea 100644
 --- a/daemon/apparmor_default.go
 +++ b/daemon/apparmor_default.go
-@@ -5,6 +5,7 @@ package daemon // import "github.com/docker/docker/daemon"
+@@ -4,6 +4,7 @@ package daemon
  
  import (
  	"fmt"
 +	"os"
  
- 	"github.com/containerd/containerd/pkg/apparmor"
- 	aaprofile "github.com/docker/docker/profiles/apparmor"
-@@ -32,7 +33,7 @@ func ensureDefaultAppArmorProfile() error {
+ 	"github.com/containerd/containerd/v2/pkg/apparmor"
+ 	aaprofile "github.com/moby/profiles/apparmor"
+@@ -31,7 +32,7 @@ func ensureDefaultAppArmorProfile() error {
  		}
  
  		// Nothing to do.
@@ -29,5 +29,5 @@ index 6376001613..d9be0dc683 100644
  		}
  
 -- 
-2.25.1
+2.43.0
 

--- a/patches/engine/0002-snappy-apparmor-tweaks.patch
+++ b/patches/engine/0002-snappy-apparmor-tweaks.patch
@@ -1,7 +1,7 @@
-From 1534b01a725498de64971edbc0614f502428b215 Mon Sep 17 00:00:00 2001
+From ae64e3ffa171c7b40e768755fbc0ece9f53e2862 Mon Sep 17 00:00:00 2001
 From: Lincoln Wallace <lincoln.wallace@canonical.com>
 Date: Fri, 5 Sep 2025 08:52:16 -0300
-Subject: [PATCH] snappy apparmor tweaks
+Subject: [PATCH 2/6] snappy apparmor tweaks
 
 Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
  2 files changed, 25 insertions(+)
 
 diff --git a/vendor/github.com/moby/profiles/apparmor/apparmor.go b/vendor/github.com/moby/profiles/apparmor/apparmor.go
-index 445eed64e9..83ef27d941 100644
+index 445eed64e9..6f0c7b535d 100644
 --- a/vendor/github.com/moby/profiles/apparmor/apparmor.go
 +++ b/vendor/github.com/moby/profiles/apparmor/apparmor.go
 @@ -9,6 +9,7 @@ import (
@@ -52,7 +52,7 @@ index 445eed64e9..83ef27d941 100644
  }
  
 diff --git a/vendor/github.com/moby/profiles/apparmor/template.go b/vendor/github.com/moby/profiles/apparmor/template.go
-index 2ebcc218a7..9de570696b 100644
+index 2ebcc218a7..0a3ccf8ee9 100644
 --- a/vendor/github.com/moby/profiles/apparmor/template.go
 +++ b/vendor/github.com/moby/profiles/apparmor/template.go
 @@ -54,5 +54,13 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {

--- a/patches/engine/0003-snappy-buildkit-git-environ.patch
+++ b/patches/engine/0003-snappy-buildkit-git-environ.patch
@@ -1,7 +1,7 @@
-From 65d421326d7edf6a96ce7b62d0c216d1b59e6509 Mon Sep 17 00:00:00 2001
+From d823dbc8ad84febaa25ace42a695093ac93cd7d6 Mon Sep 17 00:00:00 2001
 From: Lincoln Wallace <lincoln.wallace@canonical.com>
 Date: Fri, 30 Aug 2024 11:52:32 -0300
-Subject: [PATCH 3/5] snappy buildkit git environ
+Subject: [PATCH 3/6] snappy buildkit git environ
 
 Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go b/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go
-index 5c35f9365b..b0e0fb3aef 100644
+index 39d4397947..c584b81628 100644
 --- a/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go
 +++ b/vendor/github.com/moby/buildkit/util/gitutil/git_cli.go
-@@ -183,6 +183,9 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
+@@ -188,6 +188,9 @@ func (cli *GitCLI) Run(ctx context.Context, args ...string) (_ []byte, err error
  
  		cmd.Env = []string{
  			"PATH=" + os.Getenv("PATH"),

--- a/patches/engine/0004-fix-snap-containerd-sock.patch
+++ b/patches/engine/0004-fix-snap-containerd-sock.patch
@@ -1,7 +1,7 @@
-From 14498fbf7f299641bf576cec3c19884b509aeded Mon Sep 17 00:00:00 2001
+From f01565b0c0645419f8459e5ff4b88d0ccd5bddf5 Mon Sep 17 00:00:00 2001
 From: Lincoln Wallace <lincoln.wallace@canonical.com>
 Date: Thu, 26 Jun 2025 15:01:00 -0300
-Subject: [PATCH] fix snap containerd sock
+Subject: [PATCH 4/6] fix snap containerd sock
 
 Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
 ---

--- a/patches/engine/0005-snappy-real-chroot.patch
+++ b/patches/engine/0005-snappy-real-chroot.patch
@@ -1,7 +1,7 @@
-From a65b520e0fb2dd2a2ba50ce139e0baf7812e2aa2 Mon Sep 17 00:00:00 2001
+From 32cbe39a331992aaff53b39a2f371b3b23cccfa1 Mon Sep 17 00:00:00 2001
 From: Lucas Kanashiro <lucas.kanashiro@canonical.com>
 Date: Wed, 23 Aug 2023 19:00:48 -0300
-Subject: [PATCH 5/5] snappy-real-chroot
+Subject: [PATCH 5/6] snappy-real-chroot
 
 The snappy-real-chroot.patch was changed in content because in this new
 version there is no reexec before chroot:
@@ -10,13 +10,13 @@ https://github.com/moby/moby/commit/5de229644fbda206a2ad1860ed1a73bb0a56143b
 
 Therefore the SNAP var was not set when reexecing docker-applyLayer.
 ---
- internal/mounttree/switchroot_linux.go | 7 +++++++
+ daemon/internal/mounttree/switchroot_linux.go | 7 +++++++
  1 file changed, 7 insertions(+)
 
-diff --git a/internal/mounttree/switchroot_linux.go b/internal/mounttree/switchroot_linux.go
-index 8797a04b45..ba0b45900e 100644
---- a/internal/mounttree/switchroot_linux.go
-+++ b/internal/mounttree/switchroot_linux.go
+diff --git a/daemon/internal/mounttree/switchroot_linux.go b/daemon/internal/mounttree/switchroot_linux.go
+index 31a8e0ed7a..f17b347487 100644
+--- a/daemon/internal/mounttree/switchroot_linux.go
++++ b/daemon/internal/mounttree/switchroot_linux.go
 @@ -17,6 +17,13 @@ import (
  // the desired propagation mode of path's parent mount beforehand to prevent
  // unwanted propagation into different mount namespaces.
@@ -32,5 +32,5 @@ index 8797a04b45..ba0b45900e 100644
  		if err := mount.Mount(path, path, "bind", "rbind,rw"); err != nil {
  			return realChroot(path)
 -- 
-2.25.1
+2.43.0
 

--- a/patches/engine/0006-use-realchroot-fallback-func.patch
+++ b/patches/engine/0006-use-realchroot-fallback-func.patch
@@ -1,7 +1,7 @@
-From d9a1c998cc58f2b3f4566a9b67f1646b69a55139 Mon Sep 17 00:00:00 2001
+From 6dc5ab337fed9c0028316d7d78bae5d62e0df0dc Mon Sep 17 00:00:00 2001
 From: Lincoln Wallace <lincoln.wallace@canonical.com>
 Date: Fri, 13 Jun 2025 11:50:42 -0300
-Subject: [PATCH] use realchroot fallback func
+Subject: [PATCH 6/6] use realchroot fallback func
 
 Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
  1 file changed, 12 insertions(+)
 
 diff --git a/vendor/github.com/moby/go-archive/internal/mounttree/switchroot_linux.go b/vendor/github.com/moby/go-archive/internal/mounttree/switchroot_linux.go
-index 31a8e0ed7a..aa175bb4ef 100644
+index cc0f64da68..24a3f8965e 100644
 --- a/vendor/github.com/moby/go-archive/internal/mounttree/switchroot_linux.go
 +++ b/vendor/github.com/moby/go-archive/internal/mounttree/switchroot_linux.go
 @@ -23,6 +23,18 @@ func SwitchRoot(path string) error {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: docker
-version: '28.5.2'
+version: '29.0.0'
 summary: Docker container runtime
 description: Refer to https://snapcraft.io/docker
 license: (Apache-2.0 AND MIT AND GPL-2.0)
@@ -151,7 +151,7 @@ parts:
   engine:
     plugin: make
     source: https://github.com/moby/moby.git
-    source-tag: v28.5.2
+    source-tag: docker-v29.0.0
     source-depth: 1
     override-build: |
       $CRAFT_STAGE/patches/patch.sh
@@ -186,6 +186,7 @@ parts:
       - libdevmapper-dev
       - libltdl-dev
       - libsystemd-dev
+      - libnftables-dev
       - patch
       - pkg-config
       - to armhf:
@@ -193,6 +194,8 @@ parts:
     stage-packages:
       - git
       - libltdl7
+      - libjansson4
+      - libnftables1
       - pigz
       - xz-utils
       - zfsutils-linux
@@ -209,8 +212,8 @@ parts:
   containerd:
     plugin: make
     source: https://github.com/containerd/containerd.git
-    # from https://github.com/moby/moby/blob/v28.5.2/Dockerfile#L199
-    source-tag: v1.7.28
+    # from https://github.com/moby/moby/blob/docker-v29.0.0/Dockerfile#L166
+    source-tag: v2.1.5
     source-depth: 1
     override-build: |
       make GIT_COMMIT= GIT_BRANCH= LDFLAGS=
@@ -226,7 +229,7 @@ parts:
   runc:
     plugin: make
     source: https://github.com/opencontainers/runc.git
-    # from https://github.com/moby/moby/blob/v28.5.2/Dockerfile#L290
+    # from https://github.com/moby/moby/blob/docker-v29.0.0/Dockerfile#L257
     source-tag: v1.3.3
     source-depth: 1
     override-build: |
@@ -290,7 +293,7 @@ parts:
     plugin: cmake
     source: https://github.com/krallin/tini.git
     source-type: git
-    # from https://github.com/moby/moby/blob/v28.5.2/Dockerfile#L325
+    # from https://github.com/moby/moby/blob/docker-v29.0.0/Dockerfile#L291
     source-tag: v0.19.0
     source-depth: 1
     organize:
@@ -304,7 +307,7 @@ parts:
     plugin: make
     build-snaps: *go
     source: https://github.com/docker/cli.git
-    source-tag: v28.5.2
+    source-tag: v29.0.0
     source-depth: 1
     override-build: |
       # docker build specific environment variables
@@ -331,8 +334,8 @@ parts:
   buildx:
     plugin: nil
     source: https://github.com/docker/buildx.git
-    # https://github.com/moby/moby/blob/v28.5.2/Dockerfile#L15
-    source-tag: v0.24.0
+    # https://github.com/moby/moby/blob/docker-v29.0.0/Dockerfile#L24
+    source-tag: v0.29.1
     source-depth: 1
     override-build: |
       export DESTDIR="$CRAFT_PART_INSTALL/usr/libexec/docker/cli-plugins"


### PR DESCRIPTION
Refreshes patches and gets rid of the GO111MODULE hack in the meantime.