### PR TITLE
Add ARM64 systems to spread tests

### DIFF
--- a/spread.md
+++ b/spread.md
@@ -34,6 +34,10 @@ Before running any test, you have to choose which docker snap to test
   SNAP_CHANNEL=latest/edge image-garden.spread
   ```
 
+  This runs the tests for both amd64 and arm64 architectures.
+  For testing a single architecture, download the snap and use the local snap file method.
+  To download the snap on a different architecture, e.g. arm64 on amd64, run: `UBUNTU_STORE_ARCH=arm64 snap download docker`.
+
 - To test a local snap file, specify the `SNAP_FILE_AMD64` and/or `SNAP_FILE_ARM64` variables:
 
   ```bash

--- a/spread.md
+++ b/spread.md
@@ -8,6 +8,7 @@ To get started, make sure that **image-garden** is installed on your system:
 
 ```bash
 sudo snap install image-garden
+sudo snap install image-garden+qemu-aarch64 # for arm64 emulation
 ```
 
 The snap release of image-garden also includes its dependencies, such as `spread` and `qemu`.
@@ -33,10 +34,12 @@ Before running any test, you have to choose which docker snap to test
   SNAP_CHANNEL=latest/edge image-garden.spread
   ```
 
-- To test a local snap file, specify the `SNAP_FILE` variable:
+- To test a local snap file, specify the `SNAP_FILE_AMD64` and/or `SNAP_FILE_ARM64` variables:
 
   ```bash
-  SNAP_FILE=docker_29.3.1_amd64.snap image-garden.spread
+  SNAP_FILE_AMD64=docker_29.3.1_amd64.snap \
+    SNAP_FILE_ARM64=docker_29.3.1_arm64.snap \
+    image-garden.spread
   ```
 
 The system will download the virtual machine files and place them in the `.image-garden` directory. See [Cleanup](#cleanup) to know how to free disk space.
@@ -45,13 +48,13 @@ The system will download the virtual machine files and place them in the `.image
 
 To save time you can select a subset of systems and tests to run.
 
-- To run tests on **only one system**, e.g. `ubuntu-cloud-24.04`, use:
+- To run tests on **only one system**, e.g. `ubuntu-cloud-26.04` or `ubuntu-cloud-24.04.aarch64`, use:
 
   ```bash
   image-garden.spread ubuntu-cloud-24.04:
   ```
 
-- To run an **individual spread test** on all system, use:
+- To run an **individual spread test**, e.g. `hello-world`, on all system, use:
 
   ```bash
   image-garden.spread spread/main/hello-world

--- a/spread.yaml
+++ b/spread.yaml
@@ -69,17 +69,28 @@ backends:
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
+      - ubuntu-core-24.aarch64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
       - ubuntu-cloud-24.04:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
+      - ubuntu-cloud-24.04.aarch64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
+
       - ubuntu-cloud-26.04:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
-      - ubuntu-cloud-24.04.aarch64:
+      - ubuntu-cloud-26.04.aarch64:
           username: ubuntu
           password: ubuntu
           environment:

--- a/spread.yaml
+++ b/spread.yaml
@@ -67,17 +67,23 @@ backends:
       - ubuntu-core-24:
           username: ubuntu
           password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
       - ubuntu-cloud-24.04:
           username: ubuntu
           password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
       - ubuntu-cloud-26.04:
           username: ubuntu
           password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
       - ubuntu-cloud-24.04.aarch64:
           username: ubuntu
           password: ubuntu
           environment:
-            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64) # overrides the default $SNAP_FILE_AMD64
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
 
 path: /tmp/docker
 exclude:
@@ -97,7 +103,6 @@ suites:
 environment:
   SCRIPTS_PATH: $SPREAD_PATH/spread/scripts
   SNAP_CHANNEL: $(HOST:echo $SNAP_CHANNEL) # The Snap Store channel containing the version of docker to test
-  SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64) # default value of SNAP_FILE, to be overridden by non-amd64 architectures
 
 prepare: |
   # Invoked in each system before running any test

--- a/spread.yaml
+++ b/spread.yaml
@@ -19,22 +19,35 @@ backends:
       # successfully so re-set PATH to the original value, as provided by
       # snapcraft.
       if [ -n "${SPREAD_HOST_PATH-}" ]; then
-          PATH="${SPREAD_HOST_PATH}"
+        PATH="${SPREAD_HOST_PATH}"
       fi
 
-      export QEMU_SMP_OPTION="-smp 2"
+      export QEMU_SMP_OPTION="-smp 4"
       export QEMU_MEM_OPTION="-m 3072"
 
-      ARCH="${ARCH:-$(uname -m)}"
-      if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}"."$ARCH")"; then
-            if [ "$ARCH" != "$(uname -m)" ]; then
-                  # Spread has a fixed, 5-minute timeout for ssh to become ready.
-                  # When emulating across architectures this may not be sufficient
-                  # for the system to become ready. Sleep for a while to give things
-                  # a chance to finish.
-                  sleep 3m
-            fi
-            ADDRESS "$OUT"
+      HOST_ARCH="${ARCH:-$(uname -m)}"
+      SYSTEM_ARCH="${SPREAD_SYSTEM##*.}"
+
+      # If SPREAD_SYSTEM does not already end with a valid architecture suffix,
+      # append the host architecture.
+      case "$SYSTEM_ARCH" in
+        x86_64|aarch64|amd64|arm64|armhf|i386|ppc64el|riscv64|s390x)
+          ;;
+        *)
+          SPREAD_SYSTEM="${SPREAD_SYSTEM}.${HOST_ARCH}"
+          SYSTEM_ARCH="$HOST_ARCH"
+          ;;
+      esac
+
+      if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"; then
+        if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ]; then
+          # Spread has a fixed, 5-minute timeout for ssh to become ready.
+          # When emulating across architectures this may not be sufficient
+          # for the system to become ready. Sleep for a while to give things
+          # a chance to finish.
+          sleep 3m
+        fi
+        ADDRESS "$OUT"
       fi
     discard: |
       # Spread automatically injects /snap/bin to PATH. When we are
@@ -44,7 +57,7 @@ backends:
       # successfully so re-set PATH to the original value, as provided by
       # snapcraft.
       if [ -n "${SPREAD_HOST_PATH-}" ]; then
-          PATH="${SPREAD_HOST_PATH}"
+        PATH="${SPREAD_HOST_PATH}"
       fi
 
       image-garden discard "$SPREAD_SYSTEM_ADDRESS"
@@ -60,6 +73,11 @@ backends:
       - ubuntu-cloud-26.04:
           username: ubuntu
           password: ubuntu
+      - ubuntu-cloud-24.04.aarch64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64) # overrides the default $SNAP_FILE_AMD64
 
 path: /tmp/docker
 exclude:
@@ -79,7 +97,7 @@ suites:
 environment:
   SCRIPTS_PATH: $SPREAD_PATH/spread/scripts
   SNAP_CHANNEL: $(HOST:echo $SNAP_CHANNEL) # The Snap Store channel containing the version of docker to test
-  SNAP_FILE: $(HOST:echo $SNAP_FILE) # The filename of the docker artifact to test
+  SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64) # default value of SNAP_FILE, to be overridden by non-amd64 architectures
 
 prepare: |
   # Invoked in each system before running any test


### PR DESCRIPTION
This PR adds support for ARM64 (aarch64) systems in spread tests.

The environment variables to launch spread tests targeting a local snap have changed, please see spread.md for details