### PR TITLE
Add Ubuntu 22 to spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -89,6 +89,8 @@ backends:
       - ubuntu-core-24:
           username: ubuntu
           password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
       - ubuntu-core-24.aarch64:
           username: ubuntu
           password: ubuntu

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,4 +1,5 @@
 project: docker
+kill-timeout: 30m
 backends:
   # LXD is currently not supported as a backend, because we need to set lxc instance
   # config to make docker work in an lxc container,

--- a/spread.yaml
+++ b/spread.yaml
@@ -51,7 +51,14 @@ backends:
     systems:
       # Want to add more systems? Look here for a list of available systems: https://gitlab.com/zygoon/image-garden/-/tree/main/data
       # or look here for an exhaustive example: https://gitlab.com/zygoon/image-garden/-/blob/main/spread-demo/spread.yaml
+      # Note: ubuntu core images are prepared via this script: https://gitlab.com/zygoon/image-garden/-/blob/main/mk/050-ubuntu-core.mk
+      - ubuntu-core-22:
+          username: ubuntu
+          password: ubuntu
       - ubuntu-core-24:
+          username: ubuntu
+          password: ubuntu
+      - ubuntu-cloud-22.04:
           username: ubuntu
           password: ubuntu
       - ubuntu-cloud-24.04:

--- a/spread.yaml
+++ b/spread.yaml
@@ -70,11 +70,21 @@ backends:
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
+      - ubuntu-core-22.aarch64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
       - ubuntu-cloud-22.04:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
+      - ubuntu-cloud-22.04.aarch64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
 
       - ubuntu-core-24:
           username: ubuntu


### PR DESCRIPTION
This PR adds Ubuntu Core 22 and Ubuntu Cloud 22.04 images to the spread test systems pool