### PR TITLE
Always include architecture suffix in spread systems

### DIFF
--- a/spread.md
+++ b/spread.md
@@ -52,10 +52,16 @@ The system will download the virtual machine files and place them in the `.image
 
 To save time you can select a subset of systems and tests to run.
 
-- To run tests on **only one system**, e.g. `ubuntu-cloud-26.04` or `ubuntu-cloud-24.04.aarch64`, use:
+- To run tests on **only one system**, e.g. `ubuntu-cloud-26.04.amd64` or `ubuntu-cloud-24.04.arm64`, use:
 
   ```bash
-  image-garden.spread ubuntu-cloud-24.04:
+  image-garden.spread ubuntu-cloud-24.04.amd64:
+  ```
+
+- To run tests on only **one system architecture**, e.g. `arm64`, use the `...` wildcard:
+
+  ```bash
+  image-garden.spread garden:...arm64:
   ```
 
 - To run an **individual spread test**, e.g. `hello-world`, on all system, use:
@@ -67,7 +73,7 @@ To save time you can select a subset of systems and tests to run.
 - To run only **one test** on only **one system**, combine the two:
 
   ```bash
-  image-garden.spread ubuntu-cloud-24.04:spread/main/hello-world
+  image-garden.spread ubuntu-cloud-24.04.amd64:spread/main/hello-world
   ```
 
 ### Keep test artifacts

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,14 +26,9 @@ backends:
       export QEMU_SMP_OPTION="-smp 4"
       export QEMU_MEM_OPTION="-m 3072"
 
-      # Patch spread system architecture.
-      # Spread system names can't contain underscores, so we can't include
-      # the "x86_64" suffix. We replace "x86-64" -> "x86_64",
-      # but also "amd64" -> "x86_64" and "arm64" -> "aarch64"
-      # for easy of use
-      SPREAD_SYSTEM=${SPREAD_SYSTEM/%x86-64/x86_64}
-      SPREAD_SYSTEM=${SPREAD_SYSTEM/%amd64/x86_64}
-      SPREAD_SYSTEM=${SPREAD_SYSTEM/%arm64/aarch64}
+      # Map spread system architecture
+      SPREAD_SYSTEM=${SPREAD_SYSTEM/%amd64/x86_64}  # maps "amd64" to "x86_64"
+      SPREAD_SYSTEM=${SPREAD_SYSTEM/%arm64/aarch64} # maps "arm64" to "aarch64"
 
       if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"; then
         HOST_ARCH="${ARCH:-$(uname -m)}"
@@ -64,54 +59,54 @@ backends:
       # Want to add more systems? Look here for a list of available systems: https://gitlab.com/zygoon/image-garden/-/tree/main/data
       # or look here for an exhaustive example: https://gitlab.com/zygoon/image-garden/-/blob/main/spread-demo/spread.yaml
       # Note: ubuntu core images are prepared via this script: https://gitlab.com/zygoon/image-garden/-/blob/main/mk/050-ubuntu-core.mk
-      - ubuntu-core-22.x86-64:
+      - ubuntu-core-22.amd64:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
-      - ubuntu-core-22.aarch64:
+      - ubuntu-core-22.arm64:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
-      - ubuntu-cloud-22.04.x86-64:
+      - ubuntu-cloud-22.04.amd64:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
-      - ubuntu-cloud-22.04.aarch64:
-          username: ubuntu
-          password: ubuntu
-          environment:
-            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
-
-      - ubuntu-core-24.x86-64:
-          username: ubuntu
-          password: ubuntu
-          environment:
-            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
-      - ubuntu-core-24.aarch64:
-          username: ubuntu
-          password: ubuntu
-          environment:
-            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
-      - ubuntu-cloud-24.04.x86-64:
-          username: ubuntu
-          password: ubuntu
-          environment:
-            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
-      - ubuntu-cloud-24.04.aarch64:
+      - ubuntu-cloud-22.04.arm64:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
 
-      - ubuntu-cloud-26.04.x86-64:
+      - ubuntu-core-24.amd64:
           username: ubuntu
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
-      - ubuntu-cloud-26.04.aarch64:
+      - ubuntu-core-24.arm64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
+      - ubuntu-cloud-24.04.amd64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
+      - ubuntu-cloud-24.04.arm64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
+
+      - ubuntu-cloud-26.04.amd64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_AMD64)
+      - ubuntu-cloud-26.04.arm64:
           username: ubuntu
           password: ubuntu
           environment:

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,21 +26,19 @@ backends:
       export QEMU_SMP_OPTION="-smp 4"
       export QEMU_MEM_OPTION="-m 3072"
 
-      HOST_ARCH="${ARCH:-$(uname -m)}"
-      SYSTEM_ARCH="${SPREAD_SYSTEM##*.}"
-
-      # If SPREAD_SYSTEM does not already end with a valid architecture suffix,
-      # append the host architecture.
-      case "$SYSTEM_ARCH" in
-        x86_64|aarch64|amd64|arm64|armhf|i386|ppc64el|riscv64|s390x)
-          ;;
-        *)
-          SPREAD_SYSTEM="${SPREAD_SYSTEM}.${HOST_ARCH}"
-          SYSTEM_ARCH="$HOST_ARCH"
-          ;;
-      esac
+      # Patch spread system architecture.
+      # Spread system names can't contain underscores, so we can't include
+      # the "x86_64" suffix. We replace "x86-64" -> "x86_64",
+      # but also "amd64" -> "x86_64" and "arm64" -> "aarch64"
+      # for easy of use
+      SPREAD_SYSTEM=${SPREAD_SYSTEM/%x86-64/x86_64}
+      SPREAD_SYSTEM=${SPREAD_SYSTEM/%amd64/x86_64}
+      SPREAD_SYSTEM=${SPREAD_SYSTEM/%arm64/aarch64}
 
       if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"; then
+        HOST_ARCH="${ARCH:-$(uname -m)}"
+        SYSTEM_ARCH="${SPREAD_SYSTEM##*.}"
+
         if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ]; then
           # Spread has a fixed, 5-minute timeout for ssh to become ready.
           # When emulating across architectures this may not be sufficient
@@ -66,7 +64,7 @@ backends:
       # Want to add more systems? Look here for a list of available systems: https://gitlab.com/zygoon/image-garden/-/tree/main/data
       # or look here for an exhaustive example: https://gitlab.com/zygoon/image-garden/-/blob/main/spread-demo/spread.yaml
       # Note: ubuntu core images are prepared via this script: https://gitlab.com/zygoon/image-garden/-/blob/main/mk/050-ubuntu-core.mk
-      - ubuntu-core-22:
+      - ubuntu-core-22.x86-64:
           username: ubuntu
           password: ubuntu
           environment:
@@ -76,7 +74,7 @@ backends:
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
-      - ubuntu-cloud-22.04:
+      - ubuntu-cloud-22.04.x86-64:
           username: ubuntu
           password: ubuntu
           environment:
@@ -87,7 +85,7 @@ backends:
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
 
-      - ubuntu-core-24:
+      - ubuntu-core-24.x86-64:
           username: ubuntu
           password: ubuntu
           environment:
@@ -97,7 +95,7 @@ backends:
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
-      - ubuntu-cloud-24.04:
+      - ubuntu-cloud-24.04.x86-64:
           username: ubuntu
           password: ubuntu
           environment:
@@ -108,7 +106,7 @@ backends:
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
 
-      - ubuntu-cloud-26.04:
+      - ubuntu-cloud-26.04.x86-64:
           username: ubuntu
           password: ubuntu
           environment:


### PR DESCRIPTION
This PR adds the architecture suffix to every test system in `spread.yaml`.

The main purpose of this change is to make it easier to target a single architecture by using a filter when running spread tests, for example, you can now run x86_64 tests only by executing `spread ubuntu...amd64`. 

Please note that _spread_ does not allow using the character `_` in system names, so the `x86_64` architecture suffix cannot be included in the system name. To target the `x86_64` architecture, the  `amd64` suffix is used instead. For consistency, the `arm64` suffix is used to target the `aarch64` architecture.