### PR TITLE
feat(ci): improve spread tests resilience

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -21,6 +21,12 @@ on:
   # Manual trigger
   workflow_dispatch:
 
+# Cancel an in-progress run when a newer commit lands on the same ref, so a
+# burst of pushes to a branch or PR only tests the latest one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: 'bash -Eeuo pipefail -x {0}'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -5,9 +5,19 @@ on:
     branches: [ main ]
     paths-ignore:
       - '**/*.md'
+      - 'spread/**'
+      - 'spread.yaml'
+      - '.github/workflows/spread-tests.yml'
+      - '.github/workflows/testflinger/**'
+      - '.github/workflows/nvidia-test.yml'
   pull_request:
     paths-ignore:
       - '**/*.md'
+      - 'spread/**'
+      - 'spread.yaml'
+      - '.github/workflows/spread-tests.yml'
+      - '.github/workflows/testflinger/**'
+      - '.github/workflows/nvidia-test.yml'
   # Manual trigger
   workflow_dispatch:
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -41,12 +41,12 @@ backends:
       esac
 
       if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"; then
-        if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ]; then
+        if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ] || [ ! -e /dev/kvm ]; then
           # Spread has a fixed, 5-minute timeout for ssh to become ready.
           # When emulating across architectures this may not be sufficient
           # for the system to become ready. Sleep for a while to give things
           # a chance to finish.
-          sleep 3m
+          sleep 5m
         fi
         ADDRESS "$OUT"
       fi

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,5 +1,5 @@
 project: docker
-kill-timeout: 30m
+kill-timeout: 3h
 backends:
   # LXD is currently not supported as a backend, because we need to set lxc instance
   # config to make docker work in an lxc container,

--- a/spread.yaml
+++ b/spread.yaml
@@ -40,16 +40,21 @@ backends:
           ;;
       esac
 
-      if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"; then
-        if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ] || [ ! -e /dev/kvm ]; then
-          # Spread has a fixed, 5-minute timeout for ssh to become ready.
-          # When emulating across architectures this may not be sufficient
-          # for the system to become ready. Sleep for a while to give things
-          # a chance to finish.
-          sleep 5m
-        fi
-        ADDRESS "$OUT"
+      image_garden_output="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")" || true
+
+      if [ -z "$image_garden_output" ]; then
+        ERROR "Image garden allocation failed for system: $SPREAD_SYSTEM"
       fi
+
+      if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ] || [ ! -e /dev/kvm ]; then
+        # Spread has a fixed, 5-minute timeout for ssh to become ready.
+        # When emulating across architectures this may not be sufficient
+        # for the system to become ready. Sleep for a while to give things
+        # a chance to finish.
+        sleep 5m
+      fi
+
+      ADDRESS "$image_garden_output"
     discard: |
       # Spread automatically injects /snap/bin to PATH. When we are
       # running from the image-garden snap then SPREAD_HOST_PATH is the

--- a/spread.yaml
+++ b/spread.yaml
@@ -43,7 +43,17 @@ backends:
       image_garden_output="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")" || true
 
       if [ -z "$image_garden_output" ]; then
-        ERROR "Image garden allocation failed for system: $SPREAD_SYSTEM"
+        echo "Image garden allocation failed for system: $SPREAD_SYSTEM"
+
+        # Guard against corrupt EFI vars image (0 bytes).
+        efi_vars_img=".image-garden/${SPREAD_SYSTEM}.efi-vars.img"
+        if [ -f "$efi_vars_img" ] && [ ! -s "$efi_vars_img" ]; then
+          echo "Found zero-byte EFI vars image: $efi_vars_img"
+          rm -f "$efi_vars_img"
+          image-garden make "${SPREAD_SYSTEM/-plus-/+}.efi-vars.img"
+        fi
+
+        ERROR "Image garden allocation failed"
       fi
 
       if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ] || [ ! -e /dev/kvm ]; then

--- a/spread/main/build/task.yaml
+++ b/spread/main/build/task.yaml
@@ -1,21 +1,24 @@
 summary: Test create a simple image with dockerfile
 
 execute: |
-    # create a dockerfile 
-    dockerfile=$(cat <<EOF
-      FROM alpine
-      CMD echo "hello-world"
-    EOF
-    )
-    # build an image from stdin
-    echo "$dockerfile" | sudo docker build -t test -
 
-    # run the container
-    id=$(sudo docker run -dit test)
+  source "$SCRIPTS_PATH/common.sh"
 
-    # wait a bit and check the status 
-    sleep 1
-    [ `sudo docker inspect -f '{{.State.Status}}' $id` = "exited" ] || exit 1
+  # create a dockerfile
+  dockerfile=$(cat <<EOF
+    FROM alpine
+    CMD echo "hello-world"
+  EOF
+  )
+  # build an image from stdin
+  echo "$dockerfile" | sudo docker build -t test -
 
-    #rm the container
-    sudo docker rm -f $id 
+  # run the container
+  id=$(sudo docker run -dit test)
+
+  # wait a bit and check the status
+  sleep 1
+  run_retry_command [ `sudo docker inspect -f '{{.State.Status}}' $id` = "exited" ]
+
+  #rm the container
+  sudo docker rm -f $id

--- a/spread/main/build/task.yaml
+++ b/spread/main/build/task.yaml
@@ -16,9 +16,13 @@ execute: |
   # run the container
   id=$(sudo docker run -dit test)
 
-  # wait a bit and check the status
-  sleep 1
-  run_retry_command [ `sudo docker inspect -f '{{.State.Status}}' $id` = "exited" ]
+  # wait for the container to run and exit. Wrapped in a function so the
+  # docker inspect is re-evaluated on each retry: passed inline, the command
+  # substitution would expand once and retry a frozen value.
+  verify_container_exited() {
+    [ "$(sudo docker inspect -f '{{.State.Status}}' $id)" = "exited" ]
+  }
+  run_retry_command verify_container_exited
 
   #rm the container
   sudo docker rm -f $id

--- a/spread/main/restart_always/task.yaml
+++ b/spread/main/restart_always/task.yaml
@@ -1,28 +1,33 @@
 summary: Test container restart policy with always applied
 
 execute: |
- # read docker file from stdin and build the image
- dockerfile=$(cat <<EOF
-   FROM alpine
-   CMD sleep 1; exit 1
- EOF
- )
- echo "$dockerfile" | sudo docker build -t image -
 
- # run a container which applied always restart policy
- # if the container exits with a non-zero exit status
- id=$(sudo docker run --restart always -dit image)
+  source "$SCRIPTS_PATH/common.sh"
 
- # check the restart policy and maximum retry count
- restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}' $id)
- [ $restart_policy = "always" ] || exit 1
+  # read docker file from stdin and build the image
+  dockerfile=$(cat <<EOF
+    FROM alpine
+    CMD sleep 1; exit 1
+  EOF
+  )
+  echo "$dockerfile" | sudo docker build -t image -
 
- # wait a bit and let service restarts several times
- sleep 6
+  # run a container which applied always restart policy
+  # if the container exits with a non-zero exit status
+  id=$(sudo docker run --restart always -dit image)
 
- # check the actual restart count
- restart_count=$(sudo docker inspect -f '{{.RestartCount}}' $id)
- [ $restart_count -gt 1 ] || exit 1
+  # check the restart policy and maximum retry count
+  restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}' $id)
+  [ $restart_policy = "always" ] || exit 1
 
- # remove the container
- sudo docker rm -f $id
+  function verify_restart_counter() {
+    restart_count=$(sudo docker inspect -f '{{.RestartCount}}' $id)
+    [ $restart_count -gt 1 ]
+  }
+
+  # wait a bit and let service restarts several times
+  sleep 6
+  run_retry_command verify_restart_counter
+
+  # remove the container
+  sudo docker rm -f $id

--- a/spread/main/restart_on_failure/task.yaml
+++ b/spread/main/restart_on_failure/task.yaml
@@ -2,30 +2,36 @@ summary: Test container restart policy with on_failure applied
 
 execute: |
 
- # read docker file from stdin and build the image
- dockerfile=$(cat <<EOF
-   FROM alpine
-   CMD sleep 1; exit 1
- EOF
- )
- echo "$dockerfile" | sudo docker build -t image -
+  source "$SCRIPTS_PATH/common.sh"
 
- # run a container and limit the number of restart retries (2 times) 
- # if the container exits with a non-zero exit status
- id=$(sudo docker run --restart on-failure:2 -dit image)
+  # read docker file from stdin and build the image
+  dockerfile=$(cat <<EOF
+    FROM alpine
+    CMD sleep 1; exit 1
+  EOF
+  )
+  echo "$dockerfile" | sudo docker build -t image -
 
- # check the restart policy and maximum retry count
- restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}'  $id)
- [ $restart_policy = "on-failure" ] || exit 1
- maximumretry_count=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.MaximumRetryCount}}' $id)
- [ $maximumretry_count = 2 ] || exit 1
+  # run a container and limit the number of restart retries (2 times)
+  # if the container exits with a non-zero exit status
+  id=$(sudo docker run --restart on-failure:2 -dit image)
 
- # wait a bit and let service restarts several times
- sleep 6
+  # check the restart policy and maximum retry count
+  restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}'  $id)
+  [ $restart_policy = "on-failure" ] || exit 1
 
- # check the actual restart count
- restart_count=$(sudo docker inspect -f '{{.RestartCount}}' $id)
- [ $restart_count = 2 ] || exit 1
+  maximumretry_count=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.MaximumRetryCount}}' $id)
+  [ $maximumretry_count = 2 ] || exit 1
 
- # remove the container
- sudo docker rm -f $id
+  # wait a bit and let service restarts several times
+  sleep 6
+
+  function verify_restart_counter() {
+    restart_count=$(sudo docker inspect -f '{{.RestartCount}}' $id)
+    [ $restart_count = 2 ]
+  }
+
+  run_retry_command verify_restart_counter
+
+  # remove the container
+  sudo docker rm -f $id

--- a/spread/main/update_policy/task.yaml
+++ b/spread/main/update_policy/task.yaml
@@ -1,41 +1,47 @@
 summary: Test update container's restart policy
 
 execute: |
- # read docker file from stdin and build the image
- dockerfile=$(cat <<EOF
-   FROM alpine
-   CMD sleep 5; exit 1
- EOF
- )
- echo "$dockerfile" | sudo docker build -t image -
 
- # run a container which applied always restart policy
- # if the container exits with a non-zero exit status
- id=$(sudo docker run --restart always -dit image)
+  source "$SCRIPTS_PATH/common.sh"
 
- # check the restart policy
- restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}' $id)
- [ $restart_policy = "always" ] || exit 1
+  # read docker file from stdin and build the image
+  dockerfile=$(cat <<EOF
+    FROM alpine
+    CMD sleep 5; exit 1
+  EOF
+  )
+  echo "$dockerfile" | sudo docker build -t image -
 
- # pause processes in the container
- sudo docker pause $id
+  # run a container which applied always restart policy
+  # if the container exits with a non-zero exit status
+  id=$(sudo docker run --restart always -dit image)
 
- # update restart policy
- sudo docker update --restart=no $id
+  # check the restart policy
+  restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}' $id)
+  [ $restart_policy = "always" ] || exit 1
 
- # unpause processes
- sudo docker unpause $id
+  # pause processes in the container
+  sudo docker pause $id
 
- # check the restart policy
- restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}' $id)
- [ $restart_policy = "no" ] || exit 1
+  # update restart policy
+  sudo docker update --restart=no $id
 
- # wait a bit and check if service restarts
- sleep 10
+  # unpause processes
+  sudo docker unpause $id
 
- # check the actual restart count
- restart_count=$(sudo docker inspect -f '{{.RestartCount}}' $id)
- [ $restart_count = 0 ] || exit 1
+  # check the restart policy
+  restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}' $id)
+  [ $restart_policy = "no" ] || exit 1
 
- # remove the container
- sudo docker rm -f $id
+  # wait a bit and check if service restarts
+  sleep 10
+
+  function verify_restart_counter() {
+    restart_count=$(sudo docker inspect -f '{{.RestartCount}}' $id)
+    [ $restart_count = 0 ]
+  }
+
+  run_retry_command verify_restart_counter
+
+  # remove the container
+  sudo docker rm -f $id

--- a/spread/main/update_policy/task.yaml
+++ b/spread/main/update_policy/task.yaml
@@ -7,7 +7,7 @@ execute: |
   # read docker file from stdin and build the image
   dockerfile=$(cat <<EOF
     FROM alpine
-    CMD sleep 5; exit 1
+    CMD sleep 1m; exit 1
   EOF
   )
   echo "$dockerfile" | sudo docker build -t image -
@@ -33,8 +33,8 @@ execute: |
   restart_policy=$(sudo docker inspect  -f '{{.HostConfig.RestartPolicy.Name}}' $id)
   [ $restart_policy = "no" ] || exit 1
 
-  # wait a bit and check if service restarts
-  sleep 10
+  # wait enough for the container to exit, and verify that it didn't restart
+  sleep 1.5m
 
   function verify_restart_counter() {
     restart_count=$(sudo docker inspect -f '{{.RestartCount}}' $id)

--- a/spread/scripts/common.sh
+++ b/spread/scripts/common.sh
@@ -1,27 +1,25 @@
 #!/bin/bash
 
-wait_for_docker() {
-    num_tries=0
-	MAX_TRIES=60
+run_retry_command() {
+  local RETRIES=30
+  local DELAY=6
+  local n=1
+  until "$@"; do
+    if [[ $n -ge $RETRIES ]]; then
+      ERROR "Command failed after $RETRIES attempts: $*"
+    fi
+    echo "Command failed (attempt $n/$RETRIES): $*. Retrying in $DELAY seconds..."
+    ((n++))
+    sleep $DELAY
+  done
+}
 
-    until docker info; do
-        num_tries=$((num_tries+1))
-        if (( num_tries > MAX_TRIES )); then
-            ERROR "max tries waiting for docker daemon to come online"
-        fi
-        sleep 1
-    done
+wait_for_docker() {
+    echo "Waiting for docker to become available..."
+    run_retry_command docker info
 }
 
 restart_docker() {
-    num_tries=0
-	MAX_TRIES=5
-
-    until snap restart docker; do
-        num_tries=$((num_tries+1))
-        if (( num_tries > MAX_TRIES )); then
-            ERROR "docker daemon failed to restart"
-        fi
-        sleep 5
-    done
+    echo "Restarting docker daemon..."
+    run_retry_command sudo snap restart docker
 }


### PR DESCRIPTION
Spread tests may fail in slower systems due to time-related issues, especially if emulating a different architecture.

This PR tries to improve tests resilience by:

- increasing the task timeout
- increasing the provisioning wait time if KVM is not available
- converting tests to use a retry logic instead of blindly rely on sleeping
- retrying image-garden allocations on failure