### PR TITLE
Add spread tests workflow

### DIFF
--- a/.github/workflows/spread-tests.yml
+++ b/.github/workflows/spread-tests.yml
@@ -1,0 +1,79 @@
+name: Spread Tests
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      snap_channel:
+        description: "Snap Store channel containing the version of docker to test"
+        required: true
+        type: string
+      spread_test_filter:
+        description: "Spread test selection filter; use '...' as a wildcard"
+        required: false
+        type: string
+        default: ''
+
+defaults:
+  run:
+    shell: 'bash -Eeuo pipefail -x {0}'
+
+jobs:
+  spread-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - label: [ self-hosted-linux-amd64-noble-large ]
+            spread_target_arch: amd64
+          - label: [ self-hosted-linux-arm64-noble-large ]
+            spread_target_arch: arm64
+    runs-on: ${{ matrix.runner.label }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Prep
+        run: |
+          sudo snap install image-garden --channel=latest/edge
+          sudo snap install image-garden+qemu-aarch64 || true
+          sudo snap install image-garden+qemu-riscv64 || true
+
+          # We need write access to /dev/kvm for better performance.
+          # Since this is an ephemeral CI/CD environment, we can grant everyone access to /dev/kvm.
+          sudo chmod -v 666 /dev/kvm || true
+
+      - name: Cache pristine virtual machine images
+        uses: actions/cache@v5
+        with:
+          path: ~/snap/image-garden/common/cache/dl
+          key: image-garden-dl-${{ matrix.runner.spread_target_arch }}
+
+      - name: Run spread tests
+        run: |
+          test_filter="ubuntu...${{ matrix.runner.spread_target_arch }}"
+
+          if [ -n "${{ inputs.spread_test_filter }}" ]; then
+            test_filter="${{ inputs.spread_test_filter }}"
+          fi
+
+          SNAP_CHANNEL="${{ inputs.snap_channel }}" image-garden.spread -v -vv "$test_filter"
+
+      - name: Log image garden content
+        if: ${{ failure() }}
+        run: |
+          echo "Image Garden directory content:"
+          ls -lah .image-garden/
+
+          echo "Image Garden cache content:"
+          ls -lah ~/snap/image-garden/common/cache/dl/
+
+      - name: Upload logs as artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: boot-logs
+          path: .image-garden/*.log
+          include-hidden-files: true
+          if-no-files-found: ignore
+          overwrite: true

--- a/.github/workflows/spread-tests.yml
+++ b/.github/workflows/spread-tests.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           sudo snap install image-garden --channel=latest/edge
           sudo snap install image-garden+qemu-aarch64 || true
-          sudo snap install image-garden+qemu-riscv64 || true
 
           # We need write access to /dev/kvm for better performance.
           # Since this is an ephemeral CI/CD environment, we can grant everyone access to /dev/kvm.

--- a/.github/workflows/spread-tests.yml
+++ b/.github/workflows/spread-tests.yml
@@ -12,7 +12,7 @@ on:
         description: "Spread test selection filter; use '...' as a wildcard"
         required: false
         type: string
-        default: ''
+        default: '...amd64'
 
 defaults:
   run:
@@ -24,10 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - label: [ self-hosted-linux-amd64-noble-large ]
-            spread_target_arch: amd64
-          - label: [ self-hosted-linux-arm64-noble-large ]
-            spread_target_arch: arm64
+          - label: ubuntu-latest
+            spread_test_filter: ${{ inputs.spread_test_filter }}
+
     runs-on: ${{ matrix.runner.label }}
     steps:
       - name: Checkout code
@@ -47,17 +46,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/snap/image-garden/common/cache/dl
-          key: image-garden-dl-${{ matrix.runner.spread_target_arch }}
+          key: image-garden-dl-${{ matrix.runner.spread_test_filter }}
 
       - name: Run spread tests
         run: |
-          test_filter="ubuntu...${{ matrix.runner.spread_target_arch }}"
-
-          if [ -n "${{ inputs.spread_test_filter }}" ]; then
-            test_filter="${{ inputs.spread_test_filter }}"
-          fi
-
-          SNAP_CHANNEL="${{ inputs.snap_channel }}" image-garden.spread -v -vv "$test_filter"
+          SNAP_CHANNEL="${{ inputs.snap_channel }}" image-garden.spread -v -vv "${{ matrix.runner.spread_test_filter }}"
 
       - name: Log image garden content
         if: ${{ failure() }}

--- a/spread.yaml
+++ b/spread.yaml
@@ -30,19 +30,23 @@ backends:
       SPREAD_SYSTEM=${SPREAD_SYSTEM/%amd64/x86_64}  # maps "amd64" to "x86_64"
       SPREAD_SYSTEM=${SPREAD_SYSTEM/%arm64/aarch64} # maps "arm64" to "aarch64"
 
-      if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"; then
-        HOST_ARCH="${ARCH:-$(uname -m)}"
-        SYSTEM_ARCH="${SPREAD_SYSTEM##*.}"
+      image_garden_output="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"
 
-        if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ]; then
-          # Spread has a fixed, 5-minute timeout for ssh to become ready.
-          # When emulating across architectures this may not be sufficient
-          # for the system to become ready. Sleep for a while to give things
-          # a chance to finish.
-          sleep 3m
-        fi
-        ADDRESS "$OUT"
+      if [ -z "$image_garden_output" ]; then
+        ERROR "Image garden allocation failed for system $SPREAD_SYSTEM"
       fi
+
+      HOST_ARCH="${ARCH:-$(uname -m)}"
+      SYSTEM_ARCH="${SPREAD_SYSTEM##*.}"
+      if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ] || [ ! -e /dev/kvm ]; then
+        # Spread has a fixed, 5-minute timeout for ssh to become ready.
+        # When emulating across architectures this may not be sufficient
+        # for the system to become ready. Sleep for a while to give things
+        # a chance to finish.
+        sleep 5m
+      fi
+
+      ADDRESS "$image_garden_output"
     discard: |
       # Spread automatically injects /snap/bin to PATH. When we are
       # running from the image-garden snap then SPREAD_HOST_PATH is the

--- a/spread.yaml
+++ b/spread.yaml
@@ -30,23 +30,19 @@ backends:
       SPREAD_SYSTEM=${SPREAD_SYSTEM/%amd64/x86_64}  # maps "amd64" to "x86_64"
       SPREAD_SYSTEM=${SPREAD_SYSTEM/%arm64/aarch64} # maps "arm64" to "aarch64"
 
-      image_garden_output="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"
+      if OUT="$(image-garden allocate "${SPREAD_SYSTEM/-plus-/+}")"; then
+        HOST_ARCH="${ARCH:-$(uname -m)}"
+        SYSTEM_ARCH="${SPREAD_SYSTEM##*.}"
 
-      if [ -z "$image_garden_output" ]; then
-        ERROR "Image garden allocation failed for system $SPREAD_SYSTEM"
+        if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ]; then
+          # Spread has a fixed, 5-minute timeout for ssh to become ready.
+          # When emulating across architectures this may not be sufficient
+          # for the system to become ready. Sleep for a while to give things
+          # a chance to finish.
+          sleep 3m
+        fi
+        ADDRESS "$OUT"
       fi
-
-      HOST_ARCH="${ARCH:-$(uname -m)}"
-      SYSTEM_ARCH="${SPREAD_SYSTEM##*.}"
-      if [ "$HOST_ARCH" != "$SYSTEM_ARCH" ] || [ ! -e /dev/kvm ]; then
-        # Spread has a fixed, 5-minute timeout for ssh to become ready.
-        # When emulating across architectures this may not be sufficient
-        # for the system to become ready. Sleep for a while to give things
-        # a chance to finish.
-        sleep 5m
-      fi
-
-      ADDRESS "$image_garden_output"
     discard: |
       # Spread automatically injects /snap/bin to PATH. When we are
       # running from the image-garden snap then SPREAD_HOST_PATH is the


### PR DESCRIPTION
This PR adds a manually triggered workflow that runs spread tests targeting amd64 systems only.

Here is a [link](https://github.com/canonical/docker-snap/actions/runs/24990308940/job/73173982341) to successful run.

The workflow takes about 8-9 minutes to run, so it is possible to automatically run it on pull requests