### PR TITLE
Add riscv64 systems to spread tests

### DIFF
--- a/spread.md
+++ b/spread.md
@@ -9,6 +9,7 @@ To get started, make sure that **image-garden** is installed on your system:
 ```bash
 sudo snap install image-garden
 sudo snap install image-garden+qemu-aarch64 # for arm64 emulation
+sudo snap install image-garden+qemu-riscv64 # for riscv64 emulation
 ```
 
 The snap release of image-garden also includes its dependencies, such as `spread` and `qemu`.
@@ -38,11 +39,12 @@ Before running any test, you have to choose which docker snap to test
   For testing a single architecture, download the snap and use the local snap file method.
   To download the snap on a different architecture, e.g. arm64 on amd64, run: `UBUNTU_STORE_ARCH=arm64 snap download docker`.
 
-- To test a local snap file, specify the `SNAP_FILE_AMD64` and/or `SNAP_FILE_ARM64` variables:
+- To test a local snap file, specify the `SNAP_FILE_AMD64`, `SNAP_FILE_ARM64` and/or `SNAP_FILE_RISCV64`:
 
   ```bash
   SNAP_FILE_AMD64=docker_29.3.1_amd64.snap \
     SNAP_FILE_ARM64=docker_29.3.1_arm64.snap \
+    SNAP_FILE_RISCV64=docker_29.3.1_riscv.snap \
     image-garden.spread
   ```
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -100,6 +100,11 @@ backends:
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
+      - ubuntu-cloud-24.04.riscv64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_RISCV64)
 
       - ubuntu-cloud-26.04.amd64:
           username: ubuntu
@@ -111,6 +116,11 @@ backends:
           password: ubuntu
           environment:
             SNAP_FILE: $(HOST:echo $SNAP_FILE_ARM64)
+      - ubuntu-cloud-26.04.riscv64:
+          username: ubuntu
+          password: ubuntu
+          environment:
+            SNAP_FILE: $(HOST:echo $SNAP_FILE_RISCV64)
 
 path: /tmp/docker
 exclude:


### PR DESCRIPTION
This PR adds RISCV 64 systems to the spread test systems pool. 

As of right now, the only ubuntu versions with RISCV64 qemu images available in image-garden are _Ubuntu Cloud 24.04_ and _Ubuntu Cloud 26.04_

To run spread tests targeting the newly added _riscv64_ systems, make sure the required `qemu-riscv64` component is installed:

```shell
sudo snap install image-garden+qemu-riscv64 # for riscv64 emulation
```

Then, use the following to run all _riscv64_ tests:

```shell
SNAP_CHANNEL=edge image-garden.spread -v -vv ...riscv64
```

Due to delays caused by emulation, #372 might be required to make some tests pass (like `update_policy`)