### PR TITLE
Upload to store on PRs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -38,7 +38,7 @@ jobs:
           snapcraft-args: snap --output docker_${{ github.run_id }}_${{ matrix.runner.arch }}.snap
 
       - name: Upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: docker_${{ github.run_id}}_${{ matrix.runner.arch }}.snap
           path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -340,3 +340,29 @@ jobs:
           COUNT="$(sudo iptables -L | grep -i docker | wc -l)"
           set -e
           [ "$COUNT" -gt 0 ]
+
+  publish:
+    needs: smoke-test
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - snap_arch: amd64
+          - snap_arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+      # Download snap artifact from the previous build job in this workflow run
+      - name: Download snap artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: docker_${{ github.run_id }}_${{ matrix.runner.snap_arch }}.snap
+      
+      # Publish snap to Store
+      - name: Publish snap to Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_LOGIN }}
+        with:
+          snap: docker_${{ github.run_id }}_${{ matrix.runner.snap_arch }}.snap
+          release: latest/edge/pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
This PR introduces an extra step to the **smoke-tests** workflow, uploading packed snaps to the Snap Store on pull requests, under the channel `latest/edge/pr-{PR-NUM}`.

Since the snap is built and smoke-tested against the `amd64` and `arm64` architectures only, those are the only ones that get uploaded to the store.

Since uploading doesn't require any specific runner architecture, `ubuntu-latest` is used as the operating system for the upload runners, regardless of the snap architecture being uploaded.