### PR TITLE
ci: use actions/download-artifact to download snap

### DIFF
--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -27,6 +27,7 @@ jobs:
               uses: actions/download-artifact@v7
               with:
                 run-id: ${{ inputs.run_id }}
+                github-token: ${{ github.token }} # required for downloading from another workflow run
                 name: docker_${{ inputs.run_id }}_amd64.snap
             
             # Publish snap to Store so it can be installed on the test devices

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -24,9 +24,9 @@ jobs:
         steps:
             # Download snap artifact from a previous smoke-test/build GitHub Workflow run
             - name: Download snap artifact
-              uses: dawidd6/action-download-artifact@v11
+              uses: actions/download-artifact@v8
               with:
-                run_id: ${{ inputs.run_id }}
+                run-id: ${{ inputs.run_id }}
                 name: docker_${{ inputs.run_id }}_amd64.snap
             
             # Publish snap to Store so it can be installed on the test devices

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -24,7 +24,7 @@ jobs:
         steps:
             # Download snap artifact from a previous smoke-test/build GitHub Workflow run
             - name: Download snap artifact
-              uses: actions/download-artifact@v7
+              uses: actions/download-artifact@v8
               with:
                 run-id: ${{ inputs.run_id }}
                 github-token: ${{ github.token }} # required for downloading from another workflow run

--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -24,7 +24,7 @@ jobs:
         steps:
             # Download snap artifact from a previous smoke-test/build GitHub Workflow run
             - name: Download snap artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@v7
               with:
                 run-id: ${{ inputs.run_id }}
                 name: docker_${{ inputs.run_id }}_amd64.snap


### PR DESCRIPTION
Use Github-maintained action to download the artifact, consistent with how it's done in [smoke-test.yml](https://github.com/canonical/docker-snap/blob/c9be5503528ab68c9f682ac29f5ac5bd26e492c8/.github/workflows/smoke-test.yml#L65-L68).