### PR TITLE
feat(core26): GPU support for Ubuntu Core 26

### DIFF
--- a/.github/workflows/nvidia-test.yml
+++ b/.github/workflows/nvidia-test.yml
@@ -50,6 +50,7 @@ jobs:
               - noble
               - core22-latest
               - core24-latest
+              - core26-latest
         env:
           TESTFLINGER_DIR: .github/workflows/testflinger
           SNAP_CHANNEL: latest/edge/runid-${{ inputs.run_id }}

--- a/.github/workflows/testflinger/README.md
+++ b/.github/workflows/testflinger/README.md
@@ -8,6 +8,7 @@ Tested distros:
 - `noble`
 - `core22-latest`
 - `core24-latest`
+- `core26-latest`
 
 ## Run on remote machine over SSH
 

--- a/.github/workflows/testflinger/scripts/setup.sh
+++ b/.github/workflows/testflinger/scripts/setup.sh
@@ -118,6 +118,7 @@ install_dependencies() {
   # Source variables that define the version.
   # e.g. core: ID=ubuntu-core, VERSION_ID="24"
   # e.g. desktop: ID=ubuntu, VERSION_ID="25.10"
+  # shellcheck disable=SC1091  # /etc/os-release is provided by the OS at runtime
   source /etc/os-release
 
   case "$ID-$VERSION_ID" in

--- a/.github/workflows/testflinger/scripts/setup.sh
+++ b/.github/workflows/testflinger/scripts/setup.sh
@@ -101,6 +101,19 @@ setup_core24() (
   install_snap mesa-2404
 )
 
+setup_core26() (
+  set -x
+  # List available kernel components for debugging
+  snap components pc-kernel
+
+  # Install kernel components.
+  PARENT_SNAP="pc-kernel"
+  COMPONENTS="nvidia-580-erd-ko nvidia-580-erd-user"
+  install_components $PARENT_SNAP "$COMPONENTS"
+
+  install_snap mesa-2604
+)
+
 install_dependencies() {
   # Source variables that define the version.
   # e.g. core: ID=ubuntu-core, VERSION_ID="24"
@@ -116,6 +129,9 @@ install_dependencies() {
     ;;
   ubuntu-core-24)
     setup_core24
+    ;;
+  ubuntu-core-26)
+    setup_core26
     ;;
   *)
     echo "Unsupported OS / version: $ID $VERSION_ID"

--- a/.github/workflows/testflinger/scripts/test.sh
+++ b/.github/workflows/testflinger/scripts/test.sh
@@ -20,7 +20,7 @@ smi_test() (
       ;;
     ubuntu-core-26)
       # Run nvidia-smi from the kernel snap
-      LD_LIBRARY_PATH=/var/snap/pc-kernel/common/kernel-gpu-2604/usr/lib/x86_64-linux-gnu/ /var/snap/pc-kernel/common/kernel-gpu-2604/usr/bin/nvidia-smi || true
+      LD_LIBRARY_PATH=/var/snap/pc-kernel/common/nvidia-active/usr/lib/x86_64-linux-gnu/ /var/snap/pc-kernel/common/nvidia-active/usr/bin/nvidia-smi || true
       ;;
     *)
       echo "Unsupported OS / version: $ID $VERSION_ID"

--- a/.github/workflows/testflinger/scripts/test.sh
+++ b/.github/workflows/testflinger/scripts/test.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+# A zero exit from nvidia-smi is not enough: a degenerate success with no GPU
+# visible would still pass. Assert the output carries the real driver banner.
+assert_driver() {
+  echo "$1"
+  echo "$1" | grep -q "Driver Version"
+}
+
 # Test nvidia-smi
 smi_test() (
+  # shellcheck disable=SC1091  # /etc/os-release is provided by the OS at runtime
   source /etc/os-release
 
   set -x
@@ -19,8 +27,14 @@ smi_test() (
       LD_LIBRARY_PATH=/var/snap/pc-kernel/common/kernel-gpu-2404/usr/lib/x86_64-linux-gnu/ /var/snap/pc-kernel/common/kernel-gpu-2404/usr/bin/nvidia-smi || true
       ;;
     ubuntu-core-26)
-      # Run nvidia-smi from the kernel snap
-      LD_LIBRARY_PATH=/var/snap/pc-kernel/common/nvidia-active/usr/lib/x86_64-linux-gnu/ /var/snap/pc-kernel/common/nvidia-active/usr/bin/nvidia-smi || true
+      # In a container, via the nvidia-smi the toolkit mounts from the docker
+      # snap's gpu-2604 component (provided by mesa-2604).
+      smi_out=$(sudo docker run --rm --runtime=nvidia --gpus all ubuntu bash -c "/snap/docker/*/gpu-2604*/usr/bin/nvidia-smi")
+      assert_driver "$smi_out"
+      # And on the host, from the kernel snap. nvidia-active points at the
+      # active nvidia component.
+      smi_out=$(LD_LIBRARY_PATH=/var/snap/pc-kernel/common/nvidia-active/usr/lib/x86_64-linux-gnu/ /var/snap/pc-kernel/common/nvidia-active/usr/bin/nvidia-smi)
+      assert_driver "$smi_out"
       ;;
     *)
       echo "Unsupported OS / version: $ID $VERSION_ID"

--- a/.github/workflows/testflinger/scripts/test.sh
+++ b/.github/workflows/testflinger/scripts/test.sh
@@ -18,6 +18,10 @@ smi_test() (
       # Run nvidia-smi from the kernel snap
       LD_LIBRARY_PATH=/var/snap/pc-kernel/common/kernel-gpu-2404/usr/lib/x86_64-linux-gnu/ /var/snap/pc-kernel/common/kernel-gpu-2404/usr/bin/nvidia-smi || true
       ;;
+    ubuntu-core-26)
+      # Run nvidia-smi from the kernel snap
+      LD_LIBRARY_PATH=/var/snap/pc-kernel/common/kernel-gpu-2604/usr/lib/x86_64-linux-gnu/ /var/snap/pc-kernel/common/kernel-gpu-2604/usr/bin/nvidia-smi || true
+      ;;
     *)
       echo "Unsupported OS / version: $ID $VERSION_ID"
       exit 1

--- a/README.md
+++ b/README.md
@@ -139,6 +139,28 @@ The provider and environment setup differs depending on the Ubuntu Core release.
 > [!NOTE]
 > It is possible to connect multiple graphic providers to the Docker snap. In such a case, the Docker snap will only utilize the content provided by the `gpu-2404` content provider. Do not connect more than one `gpu-2404` provider at the same time as the content may partially override each other.
 
+#### Ubuntu Core 26
+
+The required NVIDIA kernel objects and user-space libraries are available as optional components in the [pc-kernel](https://snapcraft.io/pc-kernel) snap (24/stable channel). These libraries can be provided to the Docker snap via the [mesa-2604](https://snapcraft.io/mesa-2604) snap.
+
+```shell
+# Install kernel components
+sudo snap install pc-kernel+nvidia-580-erd-ko
+sudo snap install pc-kernel+nvidia-580-erd-user
+
+# Install the content provider snap
+sudo snap install mesa-2604
+```
+
+Once installed, Docker snap's gpu-2604 plug automatically connects to mesa-2604:
+```console
+$ snap connections docker 
+Interface          Plug                     Slot                                 Notes
+...
+content[gpu-2604]  docker:gpu-2604          mesa-2604:gpu-2604                   -
+...
+```
+
 #### Ubuntu Core 24
 
 The required NVIDIA kernel objects and user-space libraries are available as optional components in the [pc-kernel](https://snapcraft.io/pc-kernel) snap (24/stable channel). These libraries can be provided to the Docker snap via the [mesa-2404](https://snapcraft.io/mesa-2404) snap.

--- a/nvidia/lib
+++ b/nvidia/lib
@@ -13,7 +13,7 @@ nvidia_support_disabled() {
 }
 
 nvidia_support_core() {
-    snapctl is-connected gpu-2404 || snapctl is-connected graphics-core22
+    snapctl is-connected gpu-2604 || snapctl is-connected gpu-2404 || snapctl is-connected graphics-core22
 }
 
 nvidia_support_classic() {
@@ -67,7 +67,7 @@ cdi_generate () {
     CONTENT_PATH="/usr"
     
     if [ -n "${NVIDIA_DRIVER_ROOT:-}" ]; then # UC24
-        # NVIDIA_DRIVER_ROOT comes from the pc-kernel snap, through mesa-2404
+        # NVIDIA_DRIVER_ROOT comes from the pc-kernel snap, through mesa-2404/mesa-2604
         CONTENT_PATH="${NVIDIA_DRIVER_ROOT}/usr"
     elif [ -d "${SNAP}/graphics/lib/${ARCH_TRIPLET}" ]; then # UC22
         CONTENT_PATH="${SNAP}/graphics"

--- a/nvidia/system-detection
+++ b/nvidia/system-detection
@@ -16,7 +16,7 @@ else
     exit_inf "No NVIDIA support detected. For NVIDIA support, please refer to https://github.com/canonical/docker-snap"
 fi
 
-## Running gpu-2404 wrapper for Core systems only ##
+## Running gpu wrapper for Core systems only ##
 
 # Classic does not require this wrapper #
 if nvidia_support_classic; then
@@ -24,6 +24,10 @@ if nvidia_support_classic; then
 fi
 
 if nvidia_support_core; then
+    if snapctl is-connected gpu-2604; then
+        exec "${SNAP}/gpu-2604/bin/gpu-2604-provider-wrapper" "$@"
+    fi
+
     if snapctl is-connected gpu-2404; then
         exec "${SNAP}/gpu-2404/bin/gpu-2404-provider-wrapper" "$@"
     fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,11 @@ plugs:
     interface: docker
   opengl:
   # For nvidia userspace libs support #
+  gpu-2604:
+    interface: content
+    target: $SNAP/gpu-2604
+    # This is the only relevant provider, but leaving unspecified to prevent auto-installing of the providing snap #
+    # default-provider: mesa-2604
   gpu-2404:
     interface: content
     target: $SNAP/gpu-2404
@@ -94,6 +99,7 @@ apps:
       - network-control
       - privileged
       - support
+      - gpu-2604
       - gpu-2404
       - graphics-core22
     slots:
@@ -113,6 +119,7 @@ apps:
     command: bin/nvidia-container-toolkit
     daemon: oneshot
     plugs:
+      - gpu-2604
       - gpu-2404
       - graphics-core22
     before:
@@ -131,6 +138,7 @@ parts:
       nvidia/nvidia-container-toolkit-connect-hook: bin/
       nvidia/system-detection: bin/
       nvidia/gpu-2404-optional-wrapper: bin/
+      nvidia/gpu-2604-optional-wrapper: bin/
     stage:
       - bin/*
       - usr/sbin/*


### PR DESCRIPTION
- Adds gpu support on Ubuntu Core 26, via the `gpu-2604` connection provided by the `mesa-2604` snap.
- Updates existing tests to support and include `core26`.

Currently marked as draft because not yet tested.