### PR TITLE
Upgrade to v29.5.3

### DIFF
--- a/.github/workflows/spread-tests.yml
+++ b/.github/workflows/spread-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Prep
         run: |
-          sudo snap install image-garden --channel=latest/edge
+          sudo snap install image-garden
           sudo snap install image-garden+qemu-aarch64 || true
 
           # We need write access to /dev/kvm for better performance.

--- a/.github/workflows/testflinger/scripts/setup.sh
+++ b/.github/workflows/testflinger/scripts/setup.sh
@@ -95,7 +95,7 @@ setup_core24() (
 
   # Install kernel components.
   PARENT_SNAP="pc-kernel"
-  COMPONENTS="nvidia-570-erd-ko nvidia-570-erd-user"
+  COMPONENTS="nvidia-580-erd-ko nvidia-580-erd-user"
   install_components $PARENT_SNAP "$COMPONENTS"
 
   install_snap mesa-2404

--- a/.github/workflows/testflinger/scripts/setup.sh
+++ b/.github/workflows/testflinger/scripts/setup.sh
@@ -79,7 +79,7 @@ setup_classic() (
   set -x
 
   apt_update
-  run_retry_command sudo apt-get -qqy install nvidia-driver-570
+  run_retry_command sudo apt-get -qqy install nvidia-driver-580
 )
 
 setup_core22() (

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ The required NVIDIA kernel objects and user-space libraries are available as opt
 
 ```shell
 # Install kernel components
-sudo snap install pc-kernel+nvidia-550-erd-ko
-sudo snap install pc-kernel+nvidia-550-erd-user
+sudo snap install pc-kernel+nvidia-580-erd-ko
+sudo snap install pc-kernel+nvidia-580-erd-user
 
 # Install the content provider snap
 sudo snap install mesa-2404

--- a/README.md
+++ b/README.md
@@ -144,9 +144,12 @@ The provider and environment setup differs depending on the Ubuntu Core release.
 The required NVIDIA kernel objects and user-space libraries are available as optional components in the [pc-kernel](https://snapcraft.io/pc-kernel) snap (24/stable channel). These libraries can be provided to the Docker snap via the [mesa-2404](https://snapcraft.io/mesa-2404) snap.
 
 ```shell
+# List available pc-kernel components
+snap components pc-kernel
+
 # Install kernel components
-sudo snap install pc-kernel+nvidia-580-erd-ko
-sudo snap install pc-kernel+nvidia-580-erd-user
+sudo snap install pc-kernel+nvidia-XXX-erd-ko
+sudo snap install pc-kernel+nvidia-XXX-erd-user
 
 # Install the content provider snap
 sudo snap install mesa-2404

--- a/patches/engine/0001-snappy-aa-profile-reload.patch
+++ b/patches/engine/0001-snappy-aa-profile-reload.patch
@@ -1,6 +1,6 @@
-From 5621af0a01cfd03acdac7363d8580af8d6699670 Mon Sep 17 00:00:00 2001
-From: Lucas Kanashiro <lucas.kanashiro@canonical.com>
-Date: Wed, 23 Aug 2023 18:54:54 -0300
+From 4a39581c2b14dac94905027d4fe0488c7928d482 Mon Sep 17 00:00:00 2001
+From: Ivano Matrisciano <ivano.matrisciano@canonical.com>
+Date: Mon, 8 Jun 2026 15:32:24 +0200
 Subject: [PATCH 1/6] snappy-aa-profile-reload
 
 ---
@@ -8,7 +8,7 @@ Subject: [PATCH 1/6] snappy-aa-profile-reload
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/daemon/apparmor_default.go b/daemon/apparmor_default.go
-index a1048e303c..55934032ea 100644
+index f4dab90707..d6d1d7faf1 100644
 --- a/daemon/apparmor_default.go
 +++ b/daemon/apparmor_default.go
 @@ -4,6 +4,7 @@ package daemon
@@ -17,17 +17,17 @@ index a1048e303c..55934032ea 100644
  	"fmt"
 +	"os"
  
- 	"github.com/containerd/containerd/v2/pkg/apparmor"
+ 	"github.com/moby/moby/v2/daemon/internal/rootless"
  	aaprofile "github.com/moby/profiles/apparmor"
-@@ -31,7 +32,7 @@ func ensureDefaultAppArmorProfile() error {
- 		}
- 
- 		// Nothing to do.
--		if loaded {
-+		if loaded && (os.Getenv("DOCKER_AA_RELOAD") == "" || os.Getenv("DOCKER_AA_RELOAD") == "0") {
- 			return nil
- 		}
+@@ -32,7 +33,7 @@ func loadDefaultAppArmorProfileIfMissing() error {
+ 	if err != nil {
+ 		return fmt.Errorf("Could not check if %s AppArmor profile was loaded: %s", defaultAppArmorProfile, err)
+ 	}
+-	if loaded {
++	if loaded && (os.Getenv("DOCKER_AA_RELOAD") == "" || os.Getenv("DOCKER_AA_RELOAD") == "0") {
+ 		return nil
+ 	}
  
 -- 
-2.43.0
+2.51.0
 

--- a/patches/engine/0002-snappy-apparmor-tweaks.patch
+++ b/patches/engine/0002-snappy-apparmor-tweaks.patch
@@ -1,64 +1,63 @@
-From ae64e3ffa171c7b40e768755fbc0ece9f53e2862 Mon Sep 17 00:00:00 2001
-From: Lincoln Wallace <lincoln.wallace@canonical.com>
-Date: Fri, 5 Sep 2025 08:52:16 -0300
+From bcc63ecfbc2ad8146c43fc24da554fc8d7b39698 Mon Sep 17 00:00:00 2001
+From: Ivano Matrisciano <ivano.matrisciano@canonical.com>
+Date: Mon, 8 Jun 2026 15:32:34 +0200
 Subject: [PATCH 2/6] snappy apparmor tweaks
 
-Signed-off-by: Lincoln Wallace <lincoln.wallace@canonical.com>
 ---
  .../moby/profiles/apparmor/apparmor.go          | 17 +++++++++++++++++
  .../moby/profiles/apparmor/template.go          |  8 ++++++++
  2 files changed, 25 insertions(+)
 
 diff --git a/vendor/github.com/moby/profiles/apparmor/apparmor.go b/vendor/github.com/moby/profiles/apparmor/apparmor.go
-index 445eed64e9..6f0c7b535d 100644
+index 244ae70fb2..5aa7f6aa54 100644
 --- a/vendor/github.com/moby/profiles/apparmor/apparmor.go
 +++ b/vendor/github.com/moby/profiles/apparmor/apparmor.go
-@@ -9,6 +9,7 @@ import (
+@@ -14,6 +14,7 @@ import (
  	"os"
  	"os/exec"
- 	"path"
+ 	"path/filepath"
 +	"strconv"
  	"strings"
  	"text/template"
  )
-@@ -26,6 +27,8 @@ type profileData struct {
+@@ -33,6 +34,8 @@ type profileData struct {
  	Imports []string
- 	// InnerImports defines the apparmor functions to import in the profile.
+ 	// InnerImports defines the AppArmor functions to import in the profile.
  	InnerImports []string
 +	// SnapSecurityLabel is the name of the peer group to use in the snap
-+       SnapSecurityLabel string
++	SnapSecurityLabel string
  }
  
- // generateDefault creates an apparmor profile from ProfileData.
-@@ -45,6 +48,20 @@ func (p *profileData) generateDefault(out io.Writer) error {
+ // generate creates an AppArmor profile from ProfileData.
+@@ -61,6 +64,20 @@ func generate(p *profileData, out io.Writer, macroExistsFn func(string) bool) er
  		p.InnerImports = append(p.InnerImports, "#include <abstractions/base>")
  	}
  
 +	// on snap distributions, we need to determine the name of the peer group
-+       // to use for communication between the container and dockerd
-+       if _, isSnap := os.LookupEnv("SNAP"); isSnap {
-+               // this uses ps to get the systemd unit for the current process
-+               cmd := exec.Command("ps", "-o", "unit=", strconv.Itoa(os.Getpid()))
-+               out, err := cmd.CombinedOutput()
-+               if err != nil {
-+                       return err
-+               }
-+               // the snapd security label, which is the peer group we want, doesn't
-+               // include the suffix ".service"
-+               p.SnapSecurityLabel = strings.TrimSuffix(strings.TrimSpace(string(out)), ".service")
-+       }
++	// to use for communication between the container and dockerd
++	if _, isSnap := os.LookupEnv("SNAP"); isSnap {
++		// this uses ps to get the systemd unit for the current process
++		cmd := exec.Command("ps", "-o", "unit=", strconv.Itoa(os.Getpid()))
++		out, err := cmd.CombinedOutput()
++		if err != nil {
++			return err
++		}
++		// the snapd security label, which is the peer group we want, doesn't
++		// include the suffix ".service"
++		p.SnapSecurityLabel = strings.TrimSuffix(strings.TrimSpace(string(out)), ".service")
++	}
 +
  	return compiled.Execute(out, p)
  }
  
 diff --git a/vendor/github.com/moby/profiles/apparmor/template.go b/vendor/github.com/moby/profiles/apparmor/template.go
-index 2ebcc218a7..0a3ccf8ee9 100644
+index 4694a6c6e1..4428c4c2c8 100644
 --- a/vendor/github.com/moby/profiles/apparmor/template.go
 +++ b/vendor/github.com/moby/profiles/apparmor/template.go
-@@ -54,5 +54,13 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
- 
-   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
-   ptrace (trace,read,tracedby,readby) peer={{.Name}},
+@@ -70,5 +70,13 @@ profile "{{.Name}}" flags=(attach_disconnected,mediate_deleted) {
+   # allow processes within the container to trace each other,
+   # provided all other LSM and yama setting allow it.
+   ptrace (trace,tracedby,read,readby) peer="{{.Name}}",
 +{{if .SnapSecurityLabel}}
 +  # Snap based docker distribution accesses
 +  #   Allow the daemon to trace/signal containers
@@ -70,5 +69,5 @@ index 2ebcc218a7..0a3ccf8ee9 100644
  }
  `
 -- 
-2.43.0
+2.51.0
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: docker
-version: '29.3.1'
+version: '29.5.3'
 summary: Docker container runtime
 description: Refer to https://snapcraft.io/docker
 license: (Apache-2.0 AND MIT AND GPL-2.0)
@@ -154,7 +154,7 @@ parts:
   engine:
     plugin: make
     source: https://github.com/moby/moby.git
-    source-tag: docker-v29.3.1
+    source-tag: docker-v29.5.3
     source-depth: 1
     override-build: |
       $CRAFT_STAGE/patches/patch.sh
@@ -177,7 +177,7 @@ parts:
       install -T bundles/dynbinary-daemon/dockerd "$CRAFT_PART_INSTALL/bin/dockerd"
       # install docker-proxy previously provided by libnetwork part
       install -T bundles/dynbinary-daemon/docker-proxy "$CRAFT_PART_INSTALL/bin/docker-proxy"
-    build-snaps: &go ['go/1.25/stable']
+    build-snaps: &go ['go/1.26/stable']
     # we get weird behavior if we mix/match Go versions throughout this one snapcraft.yml, so we use a YAML reference here to ensure we're always consistent throughout
     after: [utility-scripts]
     build-packages:
@@ -214,7 +214,7 @@ parts:
   containerd:
     plugin: make
     source: https://github.com/containerd/containerd.git
-    source-tag: v2.2.2
+    source-tag: v2.3.1
     source-depth: 1
     override-build: |
       make GIT_COMMIT= GIT_BRANCH= LDFLAGS=
@@ -230,7 +230,7 @@ parts:
   runc:
     plugin: make
     source: https://github.com/opencontainers/runc.git
-    source-tag: v1.3.4
+    source-tag: v1.4.2
     source-depth: 1
     override-build: |
       make BUILDTAGS='seccomp apparmor selinux' COMMIT=
@@ -245,7 +245,7 @@ parts:
   nvidia-container-toolkit:
     plugin: go
     source: https://github.com/NVIDIA/nvidia-container-toolkit.git
-    source-tag: v1.19.0
+    source-tag: v1.19.1
     source-depth: 1
     override-pull: &arch-restrict |
       [ "${CRAFT_ARCH_BUILD_FOR}" != "amd64" ] && \
@@ -270,7 +270,7 @@ parts:
   libnvidia-container:
     plugin: make
     source: https://github.com/NVIDIA/libnvidia-container.git
-    source-tag: v1.18.2
+    source-tag: v1.19.0
     source-depth: 1
     override-pull: *arch-restrict
     override-build: *arch-restrict
@@ -307,7 +307,7 @@ parts:
     plugin: make
     build-snaps: *go
     source: https://github.com/docker/cli.git
-    source-tag: v29.3.1
+    source-tag: v29.5.3
     source-depth: 1
     override-build: |
       # docker build specific environment variables
@@ -334,7 +334,7 @@ parts:
   buildx:
     plugin: nil
     source: https://github.com/docker/buildx.git
-    source-tag: v0.31.1
+    source-tag: v0.34.1
     source-depth: 1
     override-build: |
       export DESTDIR="$CRAFT_PART_INSTALL/usr/libexec/docker/cli-plugins"
@@ -354,7 +354,7 @@ parts:
   compose:
     plugin: make
     source: https://github.com/docker/compose.git
-    source-tag: v5.1.1
+    source-tag: v5.1.4
     source-depth: 1
     override-build: |
       make build


### PR DESCRIPTION
This PR updates docker and NVIDIA parts to the latest version. 

In addition to the above:

- Patches 1 and 2 had to be recreated due to upstream changes.
- NVIDIA tests configuration has been updated to move away from EOL drivers for Ubuntu Core 24 tests.
- Spread tests workflow has been updated to target the `stable` channel of `image-garden`, to prevent an issue in the `edge` channel from affecting our Ubuntu Core tests.
- README.md has been changed in the Ubuntu Core 24 section so we don't suggest any specific NVIDIA driver version. This is so the guide will not become outdated as newer drivers are released.