### PR TITLE
ci: use snapcraft pack to build

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -35,7 +35,7 @@ jobs:
         uses: snapcore/action-build@v1
         id: snapcraft
         with:
-          snapcraft-args: snap --output docker_${{ github.run_id }}_${{ matrix.runner.arch }}.snap
+          snapcraft-args: pack --output docker_${{ github.run_id }}_${{ matrix.runner.arch }}.snap
 
       - name: Upload
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The smoke tests have started failing at the build phase (see [example](https://github.com/canonical/docker-snap/actions/runs/27809954876)). This is because the use of `snapcraft` without `pack` to build snaps is no longer possible with snapcraft v9. 