### PR TITLE
chore: update moby to v29.7.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: docker
-version: '29.6.1'
+version: '29.7.2'
 summary: Docker container runtime
 description: Refer to https://snapcraft.io/docker
 license: (Apache-2.0 AND MIT AND GPL-2.0)
@@ -154,7 +154,7 @@ parts:
   engine:
     plugin: make
     source: https://github.com/moby/moby.git
-    source-tag: docker-v29.6.1
+    source-tag: docker-v$CRAFT_PROJECT_VERSION
     source-depth: 1
     override-build: |
       $CRAFT_STAGE/patches/patch.sh
@@ -307,7 +307,7 @@ parts:
     plugin: make
     build-snaps: *go
     source: https://github.com/docker/cli.git
-    source-tag: v29.6.1
+    source-tag: v$CRAFT_PROJECT_VERSION
     source-depth: 1
     override-build: |
       # docker build specific environment variables
@@ -334,7 +334,7 @@ parts:
   buildx:
     plugin: nil
     source: https://github.com/docker/buildx.git
-    source-tag: v0.35.0
+    source-tag: v0.36.1
     source-depth: 1
     override-build: |
       export DESTDIR="$CRAFT_PART_INSTALL/usr/libexec/docker/cli-plugins"
@@ -354,7 +354,7 @@ parts:
   compose:
     plugin: make
     source: https://github.com/docker/compose.git
-    source-tag: v5.3.1
+    source-tag: v5.5.0
     source-depth: 1
     override-build: |
       make build


### PR DESCRIPTION
containerd is not updated here, as this version of moby still depends on `containerd` v2.3.3.

`engine` and `docker-cli` parts now use `$CRAFT_PROJECT_VERSION`, so the version doesn't have to be repeated in 3 places.