### PR TITLE
fix(ci): use wildcard to match nvidia drivers in container

### DIFF
--- a/.github/workflows/testflinger/scripts/test.sh
+++ b/.github/workflows/testflinger/scripts/test.sh
@@ -32,7 +32,7 @@ smi_test() (
       assert_driver "$smi_out"
       # Then in a container, via the nvidia-smi the toolkit mounts from the
       # docker snap's gpu-2404 component.
-      smi_out=$(sudo docker run --rm --runtime=nvidia --gpus all ubuntu bash -c "/snap/docker/*/gpu-2404/usr/bin/nvidia-smi")
+      smi_out=$(sudo docker run --rm --runtime=nvidia --gpus all ubuntu bash -c "/snap/docker/*/gpu-2404*/usr/bin/nvidia-smi")
       assert_driver "$smi_out"
       ;;
     *)


### PR DESCRIPTION
In #389 I've asked to remove asterisk after `gpu-2404` (see: https://github.com/canonical/docker-snap/pull/389#discussion_r3683166266)
It seems that it was actually needed, as the nvidia-container-toolkit reports it with a suffix after the path:

```
2026-08-25T12:57:24Z docker.nvidia-container-toolkit[1515]: time="2026-08-25T12:57:24Z" level=info msg="Using /snap/docker/3595/gpu-2404-2/...
```